### PR TITLE
Add payment refund handler

### DIFF
--- a/src/Checkout/PayPalOrderTransactionCaptureService.php
+++ b/src/Checkout/PayPalOrderTransactionCaptureService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Swag\PayPal\Checkout;
 
-use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Swag\PayPal\SwagPayPal;
@@ -16,42 +15,10 @@ class PayPalOrderTransactionCaptureService
      */
     private $orderTransactionCaptureRepository;
 
-    /**
-     * @var OrderTransactionCaptureService
-     */
-    private $orderTransactionCaptureService;
-
     public function __construct(
-        EntityRepositoryInterface $orderTransactionCaptureRepository,
-        OrderTransactionCaptureService $orderTransactionCaptureService
+        EntityRepositoryInterface $orderTransactionCaptureRepository
     ) {
         $this->orderTransactionCaptureRepository = $orderTransactionCaptureRepository;
-        $this->orderTransactionCaptureService = $orderTransactionCaptureService;
-    }
-
-    public function createOrderTransactionCaptureForFullAmount(string $orderTransactionId, Context $context): string
-    {
-        return $this->orderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
-            $orderTransactionId,
-            $context
-        );
-    }
-
-    public function createOrderTransactionCaptureForCustomAmount(
-        string $orderTransactionId,
-        float $customCaptureAmount,
-        Context $context
-    ): string {
-        return $this->orderTransactionCaptureService->createOrderTransactionCaptureForCustomAmount(
-            $orderTransactionId,
-            $customCaptureAmount,
-            $context
-        );
-    }
-
-    public function deleteOrderTransactionCapture(string $orderTransactionCaptureId, Context $context): void
-    {
-        $this->orderTransactionCaptureService->deleteOrderTransactionCapture($orderTransactionCaptureId, $context);
     }
 
     public function addPayPalResourceToOrderTransactionCapture(

--- a/src/Checkout/PayPalOrderTransactionCaptureService.php
+++ b/src/Checkout/PayPalOrderTransactionCaptureService.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swag\PayPal\Checkout;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Swag\PayPal\SwagPayPal;
+
+class PayPalOrderTransactionCaptureService
+{
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderTransactionCaptureRepository;
+
+    /**
+     * @var OrderTransactionCaptureService
+     */
+    private $orderTransactionCaptureService;
+
+    public function __construct(
+        EntityRepositoryInterface $orderTransactionCaptureRepository,
+        OrderTransactionCaptureService $orderTransactionCaptureService
+    ) {
+        $this->orderTransactionCaptureRepository = $orderTransactionCaptureRepository;
+        $this->orderTransactionCaptureService = $orderTransactionCaptureService;
+    }
+
+    public function createOrderTransactionCaptureForFullAmount(string $orderTransactionId, Context $context): string
+    {
+        return $this->orderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
+            $orderTransactionId,
+            $context
+        );
+    }
+
+    public function createOrderTransactionCaptureForCustomAmount(
+        string $orderTransactionId,
+        float $customCaptureAmount,
+        Context $context
+    ): string {
+        return $this->orderTransactionCaptureService->createOrderTransactionCaptureForCustomAmount(
+            $orderTransactionId,
+            $customCaptureAmount,
+            $context
+        );
+    }
+
+    public function deleteOrderTransactionCapture(string $orderTransactionCaptureId, Context $context): void
+    {
+        $this->orderTransactionCaptureService->deleteOrderTransactionCapture($orderTransactionCaptureId, $context);
+    }
+
+    public function addPayPalResourceToOrderTransactionCapture(
+        string $orderTransactionCaptureId,
+        string $paypalResourceId,
+        string $paypalResourceType,
+        Context $context
+    ): void {
+        $data = [
+            'id' => $orderTransactionCaptureId,
+            'externalReference' => $paypalResourceId,
+            'customFields' => [
+                SwagPayPal::ORDER_TRANSACTION_CAPTURE_CUSTOM_FIELDS_PAYPAL_RESOURCE_TYPE => $paypalResourceType,
+            ],
+        ];
+        $this->orderTransactionCaptureRepository->update([$data], $context);
+    }
+}

--- a/src/Checkout/Payment/Handler/PayPalHandler.php
+++ b/src/Checkout/Payment/Handler/PayPalHandler.php
@@ -10,6 +10,7 @@ namespace Swag\PayPal\Checkout\Payment\Handler;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
@@ -74,6 +75,11 @@ class PayPalHandler extends AbstractPaymentHandler
     private $orderTransactionCaptureStateHandler;
 
     /**
+     * @var OrderTransactionCaptureService
+     */
+    private $orderTransactionCaptureService;
+
+    /**
      * @var PayPalOrderTransactionCaptureService
      */
     private $payPalOrderTransactionCaptureService;
@@ -88,6 +94,7 @@ class PayPalHandler extends AbstractPaymentHandler
         CustomIdPatchBuilder $customIdPatchBuilder,
         LoggerInterface $logger,
         OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
+        OrderTransactionCaptureService $orderTransactionCaptureService,
         PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
     ) {
         parent::__construct($orderTransactionRepo);
@@ -99,6 +106,7 @@ class PayPalHandler extends AbstractPaymentHandler
         $this->customIdPatchBuilder = $customIdPatchBuilder;
         $this->logger = $logger;
         $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
+        $this->orderTransactionCaptureService = $orderTransactionCaptureService;
         $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
     }
 
@@ -235,7 +243,7 @@ class PayPalHandler extends AbstractPaymentHandler
             return;
         }
 
-        $orderTransactionCaptureId = $this->payPalOrderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
+        $orderTransactionCaptureId = $this->orderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
             $transactionId,
             $context
         );

--- a/src/Checkout/Payment/Handler/PlusPuiHandler.php
+++ b/src/Checkout/Payment/Handler/PlusPuiHandler.php
@@ -10,6 +10,7 @@ namespace Swag\PayPal\Checkout\Payment\Handler;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
@@ -94,6 +95,11 @@ class PlusPuiHandler
     private $orderTransactionCaptureStateHandler;
 
     /**
+     * @var OrderTransactionCaptureService
+     */
+    private $orderTransactionCaptureService;
+
+    /**
      * @var PayPalOrderTransactionCaptureService
      */
     private $payPalOrderTransactionCaptureService;
@@ -109,6 +115,7 @@ class PlusPuiHandler
         OrderTransactionStateHandler $orderTransactionStateHandler,
         LoggerInterface $logger,
         OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
+        OrderTransactionCaptureService $orderTransactionCaptureService,
         PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
     ) {
         $this->paymentResource = $paymentResource;
@@ -121,6 +128,7 @@ class PlusPuiHandler
         $this->orderTransactionStateHandler = $orderTransactionStateHandler;
         $this->logger = $logger;
         $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
+        $this->orderTransactionCaptureService = $orderTransactionCaptureService;
         $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
     }
 
@@ -381,7 +389,7 @@ class PlusPuiHandler
         string $partnerAttributionId,
         Context $context
     ): Payment {
-        $orderTransactionCaptureId = $this->payPalOrderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
+        $orderTransactionCaptureId = $this->orderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
             $transactionId,
             $context
         );
@@ -409,7 +417,7 @@ class PlusPuiHandler
             $paypalResource = $relatedResource->getSale();
             $paypalResourceCompletedState = PaymentStatusV1::PAYMENT_SALE_COMPLETED;
         } else {
-            $this->payPalOrderTransactionCaptureService->deleteOrderTransactionCapture(
+            $this->orderTransactionCaptureService->deleteOrderTransactionCapture(
                 $orderTransactionCaptureId,
                 $context
             );

--- a/src/Checkout/Payment/Handler/PlusPuiHandler.php
+++ b/src/Checkout/Payment/Handler/PlusPuiHandler.php
@@ -104,6 +104,11 @@ class PlusPuiHandler
      */
     private $payPalOrderTransactionCaptureService;
 
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderTransactionCaptureRepository;
+
     public function __construct(
         PaymentResource $paymentResource,
         EntityRepositoryInterface $orderTransactionRepo,
@@ -116,7 +121,8 @@ class PlusPuiHandler
         LoggerInterface $logger,
         OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
         OrderTransactionCaptureService $orderTransactionCaptureService,
-        PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
+        PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService,
+        EntityRepositoryInterface $orderTransactionCaptureRepository
     ) {
         $this->paymentResource = $paymentResource;
         $this->orderTransactionRepo = $orderTransactionRepo;
@@ -130,6 +136,7 @@ class PlusPuiHandler
         $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
         $this->orderTransactionCaptureService = $orderTransactionCaptureService;
         $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
+        $this->orderTransactionCaptureRepository = $orderTransactionCaptureRepository;
     }
 
     public function handlePlusPayment(
@@ -417,10 +424,7 @@ class PlusPuiHandler
             $paypalResource = $relatedResource->getSale();
             $paypalResourceCompletedState = PaymentStatusV1::PAYMENT_SALE_COMPLETED;
         } else {
-            $this->orderTransactionCaptureService->deleteOrderTransactionCapture(
-                $orderTransactionCaptureId,
-                $context
-            );
+            $this->orderTransactionCaptureRepository->delete([['id' => $orderTransactionCaptureId]], $context);
 
             return $response;
         }

--- a/src/Checkout/Payment/PayPalPuiPaymentHandler.php
+++ b/src/Checkout/Payment/PayPalPuiPaymentHandler.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\Checkout\Payment;
 
 use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
@@ -61,6 +62,11 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
     private $orderTransactionCaptureStateHandler;
 
     /**
+     * @var OrderTransactionCaptureService
+     */
+    private $orderTransactionCaptureService;
+
+    /**
      * @var PayPalOrderTransactionCaptureService
      */
     private $payPalOrderTransactionCaptureService;
@@ -71,6 +77,7 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
         OrderTransactionStateHandler $orderTransactionStateHandler,
         EntityRepositoryInterface $orderTransactionRepo,
         OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
+        OrderTransactionCaptureService $orderTransactionCaptureService,
         PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
     ) {
         $this->plusPuiHandler = $plusPuiHandler;
@@ -78,6 +85,7 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
         $this->orderTransactionStateHandler = $orderTransactionStateHandler;
         $this->orderTransactionRepo = $orderTransactionRepo;
         $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
+        $this->orderTransactionCaptureService = $orderTransactionCaptureService;
         $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
     }
 
@@ -190,7 +198,7 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
         SalesChannelContext $salesChannelContext
     ): Payment {
         $context = $salesChannelContext->getContext();
-        $orderTransactionCaptureId = $this->payPalOrderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
+        $orderTransactionCaptureId = $this->orderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
             $transactionId,
             $context
         );
@@ -217,7 +225,7 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
             $paypalResource = $relatedResource->getSale();
             $paypalResourceCompletedState = PaymentStatusV1::PAYMENT_SALE_COMPLETED;
         } else {
-            $this->payPalOrderTransactionCaptureService->deleteOrderTransactionCapture(
+            $this->orderTransactionCaptureService->deleteOrderTransactionCapture(
                 $orderTransactionCaptureId,
                 $context
             );

--- a/src/Checkout/Payment/PayPalPuiPaymentHandler.php
+++ b/src/Checkout/Payment/PayPalPuiPaymentHandler.php
@@ -71,6 +71,11 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
      */
     private $payPalOrderTransactionCaptureService;
 
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderTransactionCaptureRepository;
+
     public function __construct(
         PlusPuiHandler $plusPuiHandler,
         PaymentResource $paymentResource,
@@ -78,7 +83,8 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
         EntityRepositoryInterface $orderTransactionRepo,
         OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
         OrderTransactionCaptureService $orderTransactionCaptureService,
-        PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
+        PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService,
+        EntityRepositoryInterface $orderTransactionCaptureRepository
     ) {
         $this->plusPuiHandler = $plusPuiHandler;
         $this->paymentResource = $paymentResource;
@@ -87,6 +93,7 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
         $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
         $this->orderTransactionCaptureService = $orderTransactionCaptureService;
         $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
+        $this->orderTransactionCaptureRepository = $orderTransactionCaptureRepository;
     }
 
     /**
@@ -225,10 +232,7 @@ class PayPalPuiPaymentHandler implements AsynchronousPaymentHandlerInterface
             $paypalResource = $relatedResource->getSale();
             $paypalResourceCompletedState = PaymentStatusV1::PAYMENT_SALE_COMPLETED;
         } else {
-            $this->orderTransactionCaptureService->deleteOrderTransactionCapture(
-                $orderTransactionCaptureId,
-                $context
-            );
+            $this->orderTransactionCaptureRepository->delete([['id' => $orderTransactionCaptureId]], $context);
 
             return $response;
         }

--- a/src/OrdersApi/Administration/PayPalOrdersController.php
+++ b/src/OrdersApi/Administration/PayPalOrdersController.php
@@ -9,14 +9,19 @@ namespace Swag\PayPal\OrdersApi\Administration;
 
 use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler;
 use Shopware\Core\Checkout\Payment\Exception\InvalidTransactionException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Routing\Annotation\Acl;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService;
 use Swag\PayPal\OrdersApi\Administration\Service\CaptureRefundCreator;
+use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\PartnerAttributionId;
+use Swag\PayPal\RestApi\V1\Api\Payment\Transaction\RelatedResource;
+use Swag\PayPal\RestApi\V2\PaymentStatusV2;
 use Swag\PayPal\RestApi\V2\Resource\AuthorizationResource;
 use Swag\PayPal\RestApi\V2\Resource\CaptureResource;
 use Swag\PayPal\RestApi\V2\Resource\OrderResource;
@@ -75,6 +80,16 @@ class PayPalOrdersController extends AbstractController
      */
     private $captureRefundCreator;
 
+    /**
+     * @var OrderTransactionCaptureStateHandler
+     */
+    private $orderTransactionCaptureStateHandler;
+
+    /**
+     * @var PayPalOrderTransactionCaptureService
+     */
+    private $payPalOrderTransactionCaptureService;
+
     public function __construct(
         OrderResource $orderResource,
         AuthorizationResource $authorizationResource,
@@ -82,7 +97,9 @@ class PayPalOrdersController extends AbstractController
         RefundResource $refundResource,
         EntityRepositoryInterface $orderTransactionRepository,
         PaymentStatusUtilV2 $paymentStatusUtil,
-        CaptureRefundCreator $captureRefundCreator
+        CaptureRefundCreator $captureRefundCreator,
+        OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
+        PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
     ) {
         $this->orderResource = $orderResource;
         $this->authorizationResource = $authorizationResource;
@@ -91,6 +108,8 @@ class PayPalOrdersController extends AbstractController
         $this->orderTransactionRepository = $orderTransactionRepository;
         $this->paymentStatusUtil = $paymentStatusUtil;
         $this->captureRefundCreator = $captureRefundCreator;
+        $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
+        $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
     }
 
     /**
@@ -403,13 +422,42 @@ class PayPalOrdersController extends AbstractController
     ): JsonResponse {
         $capture = $this->captureRefundCreator->createCapture($request);
 
-        $captureResponse = $this->authorizationResource->capture(
-            $authorizationId,
-            $capture,
-            $this->getSalesChannelId($orderTransactionId, $context),
-            $this->getPartnerAttributionId($request),
-            false
+        if ($capture->getAmount() !== null) {
+            $orderTransactionCaptureId = $this->payPalOrderTransactionCaptureService->createOrderTransactionCaptureForCustomAmount(
+                $orderTransactionId,
+                (float)$capture->getAmount()->getValue(),
+                $context
+            );
+        } else {
+            $orderTransactionCaptureId = $this->payPalOrderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
+                $orderTransactionId,
+                $context
+            );
+        }
+
+        try {
+            $captureResponse = $this->authorizationResource->capture(
+                $authorizationId,
+                $capture,
+                $this->getSalesChannelId($orderTransactionId, $context),
+                $this->getPartnerAttributionId($request),
+                false
+            );
+        } catch (PayPalApiException $apiException) {
+            $this->orderTransactionCaptureStateHandler->fail($orderTransactionCaptureId, $context);
+
+            throw $apiException;
+        }
+        $paypalCaptureId = $captureResponse->getId();
+        $this->payPalOrderTransactionCaptureService->addPayPalResourceToOrderTransactionCapture(
+            $orderTransactionCaptureId,
+            $paypalCaptureId,
+            RelatedResource::CAPTURE,
+            $context
         );
+        if ($captureResponse->getStatus() === PaymentStatusV2::ORDER_CAPTURE_COMPLETED) {
+            $this->orderTransactionCaptureStateHandler->complete($orderTransactionCaptureId, $context);
+        }
 
         $this->paymentStatusUtil->applyCaptureState($orderTransactionId, $captureResponse, $context);
 

--- a/src/OrdersApi/Administration/PayPalOrdersController.php
+++ b/src/OrdersApi/Administration/PayPalOrdersController.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\OrdersApi\Administration;
 
 use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler;
 use Shopware\Core\Checkout\Payment\Exception\InvalidTransactionException;
 use Shopware\Core\Framework\Context;
@@ -86,6 +87,11 @@ class PayPalOrdersController extends AbstractController
     private $orderTransactionCaptureStateHandler;
 
     /**
+     * @var OrderTransactionCaptureService
+     */
+    private $orderTransactionCaptureService;
+
+    /**
      * @var PayPalOrderTransactionCaptureService
      */
     private $payPalOrderTransactionCaptureService;
@@ -99,6 +105,7 @@ class PayPalOrdersController extends AbstractController
         PaymentStatusUtilV2 $paymentStatusUtil,
         CaptureRefundCreator $captureRefundCreator,
         OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
+        OrderTransactionCaptureService $orderTransactionCaptureService,
         PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
     ) {
         $this->orderResource = $orderResource;
@@ -109,6 +116,7 @@ class PayPalOrdersController extends AbstractController
         $this->paymentStatusUtil = $paymentStatusUtil;
         $this->captureRefundCreator = $captureRefundCreator;
         $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
+        $this->orderTransactionCaptureService = $orderTransactionCaptureService;
         $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
     }
 
@@ -423,13 +431,13 @@ class PayPalOrdersController extends AbstractController
         $capture = $this->captureRefundCreator->createCapture($request);
 
         if ($capture->getAmount() !== null) {
-            $orderTransactionCaptureId = $this->payPalOrderTransactionCaptureService->createOrderTransactionCaptureForCustomAmount(
+            $orderTransactionCaptureId = $this->orderTransactionCaptureService->createOrderTransactionCaptureForCustomAmount(
                 $orderTransactionId,
                 (float)$capture->getAmount()->getValue(),
                 $context
             );
         } else {
-            $orderTransactionCaptureId = $this->payPalOrderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
+            $orderTransactionCaptureId = $this->orderTransactionCaptureService->createOrderTransactionCaptureForFullAmount(
                 $orderTransactionId,
                 $context
             );

--- a/src/PaymentsApi/Administration/PayPalPaymentController.php
+++ b/src/PaymentsApi/Administration/PayPalPaymentController.php
@@ -108,6 +108,11 @@ class PayPalPaymentController extends AbstractController
      */
     private $payPalOrderTransactionCaptureService;
 
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderTransactionCaptureRepository;
+
     public function __construct(
         PaymentResource $paymentResource,
         SaleResource $saleResource,
@@ -119,7 +124,8 @@ class PayPalPaymentController extends AbstractController
         PriceFormatter $priceFormatter,
         OrderTransactionCaptureStateHandler $orderTransactionCaptureStateHandler,
         OrderTransactionCaptureService $orderTransactionCaptureService,
-        PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService
+        PayPalOrderTransactionCaptureService $payPalOrderTransactionCaptureService,
+        EntityRepositoryInterface $orderTransactionCaptureRepository
     ) {
         $this->paymentResource = $paymentResource;
         $this->saleResource = $saleResource;
@@ -132,6 +138,7 @@ class PayPalPaymentController extends AbstractController
         $this->orderTransactionCaptureStateHandler = $orderTransactionCaptureStateHandler;
         $this->orderTransactionCaptureService = $orderTransactionCaptureService;
         $this->payPalOrderTransactionCaptureService = $payPalOrderTransactionCaptureService;
+        $this->orderTransactionCaptureRepository = $orderTransactionCaptureRepository;
     }
 
     /**
@@ -311,10 +318,7 @@ class PayPalPaymentController extends AbstractController
                     $captureResponse = $this->ordersResource->capture($resourceId, $capture, $salesChannelId);
                     break;
                 default:
-                    $this->orderTransactionCaptureService->deleteOrderTransactionCapture(
-                        $orderTransactionCaptureId,
-                        $context
-                    );
+                    $this->orderTransactionCaptureRepository->delete([['id' => $orderTransactionCaptureId]], $context);
 
                     throw new RequiredParameterInvalidException('resourceType');
             }

--- a/src/Refund/Configs/paypal-refund-config-options.yaml
+++ b/src/Refund/Configs/paypal-refund-config-options.yaml
@@ -1,0 +1,20 @@
+- name: invoiceNumber
+  type: text
+  label:
+    en-GB: Invoice number
+    de-DE: Rechnungsnummer
+  default: ''
+
+- name: description
+  type: text
+  label:
+    en-GB: Description
+    de-DE: Beschreibung
+  default: ''
+
+- name: reason
+  type: text
+  label:
+    en-GB: Reason
+    de-DE: Anlass
+  default: ''

--- a/src/Refund/Exception/NoRefundableResourceAvailableException.php
+++ b/src/Refund/Exception/NoRefundableResourceAvailableException.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Refund\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class NoRefundableResourceAvailableException extends ShopwareHttpException
+{
+    public function __construct(string $orderTransactionId)
+    {
+        parent::__construct(
+            'No resource to refund available for order transaction "{{ orderTransactionId }}"',
+            ['orderTransactionId' => $orderTransactionId]
+        );
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SWAG_PAYPAL__NO_REFUNDABLE_RESOURCE_AVAILABLE';
+    }
+}

--- a/src/Refund/Exception/ResourceMissingInCaptureException.php
+++ b/src/Refund/Exception/ResourceMissingInCaptureException.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Refund\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResourceMissingInCaptureException extends ShopwareHttpException
+{
+    public function __construct(string $orderTransactionCaptureId)
+    {
+        parent::__construct(
+            'The resource to refund is missing in capture "{{ orderTransactionCaptureId }}"',
+            ['orderTransactionCaptureId' => $orderTransactionCaptureId]
+        );
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SWAG_PAYPAL__RESOURCE_MISSING_IN_CAPTURE';
+    }
+}

--- a/src/Refund/PayPalRefundHandler.php
+++ b/src/Refund/PayPalRefundHandler.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swag\PayPal\Refund;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundStateHandler;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundEntity;
+use Shopware\Core\Checkout\Refund\RefundHandler\PaymentRefundHandlerInterface;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Checkout\Refund\Exception\PaymentRefundProcessException;
+use Swag\PayPal\PaymentsApi\Administration\Exception\RequiredParameterInvalidException;
+use Swag\PayPal\Refund\Exception\NoRefundableResourceAvailableException;
+use Swag\PayPal\Refund\Exception\ResourceMissingInCaptureException;
+use Swag\PayPal\RestApi\V1\Api\Payment\Transaction\RelatedResource;
+use Swag\PayPal\RestApi\V1\Api\Refund;
+use Swag\PayPal\RestApi\V1\Api\Refund\Amount;
+use Swag\PayPal\RestApi\V1\PaymentStatusV1;
+use Swag\PayPal\RestApi\V1\Resource\PaymentResource;
+use Swag\PayPal\RestApi\V1\Resource\SaleResource;
+use Swag\PayPal\RestApi\V1\Resource\CaptureResource;
+use Swag\PayPal\SwagPayPal;
+use Swag\PayPal\Util\PriceFormatter;
+
+class PayPalRefundHandler implements PaymentRefundHandlerInterface
+{
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderRefundRepository;
+    /**
+     * @var PriceFormatter
+     */
+    private $priceFormatter;
+    /**
+     * @var PaymentResource
+     */
+    private $paymentResource;
+    /**
+     * @var SaleResource
+     */
+    private $saleResource;
+    /**
+     * @var CaptureResource
+     */
+    private $captureResource;
+    /**
+     * @var OrderRefundStateHandler
+     */
+    private $orderRefundStateHandler;
+
+    public function __construct(
+        EntityRepositoryInterface $orderRefundRepository,
+        PaymentResource $paymentResource,
+        SaleResource $saleResource,
+        CaptureResource $captureResource,
+        OrderRefundStateHandler $orderRefundStateHandler
+    ) {
+        $this->orderRefundRepository = $orderRefundRepository;
+        $this->paymentResource = $paymentResource;
+        $this->saleResource = $saleResource;
+        $this->captureResource = $captureResource;
+        $this->orderRefundStateHandler = $orderRefundStateHandler;
+        $this->priceFormatter = new PriceFormatter();
+    }
+
+    public function refund(string $orderRefundTransactionId, Context $context): void
+    {
+        try {
+            $criteria = new Criteria([$orderRefundTransactionId]);
+            $criteria->addAssociations([
+                'order.salesChannel',
+                'order.currency',
+                'transaction',
+                'transactionCapture',
+            ]);
+            /** @var OrderRefundEntity $orderRefund */
+            $orderRefund = $this->orderRefundRepository->search($criteria, $context)->first();
+
+            [
+                $resourceIdToRefund,
+                $resourceType,
+            ] = $this->getResourceIdAndTypeToRefund($orderRefund);
+            $refund = $this->createRefund($orderRefund);
+
+            $salesChannelId = $orderRefund->getOrder()->getSalesChannelId();
+            switch ($resourceType) {
+                case RelatedResource::SALE:
+                    $refundResponse = $this->saleResource->refund(
+                        $resourceIdToRefund,
+                        $refund,
+                        $salesChannelId
+                    );
+                    break;
+                case RelatedResource::CAPTURE:
+                    $refundResponse = $this->captureResource->refund(
+                        $resourceIdToRefund,
+                        $refund,
+                        $salesChannelId
+                    );
+                    break;
+                default:
+                    throw new RequiredParameterInvalidException('resourceType');
+            }
+            $refundAmount = $this->priceFormatter->roundPrice(
+                (float) $refundResponse->getAmount()->getTotal()
+            );
+            if ($refundAmount === $orderRefund->getAmount()) {
+                $this->orderRefundStateHandler->complete($orderRefundTransactionId, $context);
+            } else {
+                $this->orderRefundStateHandler->fail($orderRefundTransactionId, $context);
+            }
+        } catch (\Throwable $e) {
+            throw new PaymentRefundProcessException($orderRefundTransactionId, $e->getMessage());
+        }
+    }
+
+    private function createRefund(OrderRefundEntity $orderRefund): Refund
+    {
+        $refundAmount = $this->priceFormatter->formatPrice($orderRefund->getAmount());
+        $currency = $orderRefund->getOrder()->getCurrency()->getShortName();
+        $options = $orderRefund->getOptions() ?? [];
+        $invoiceNumber = $options['invoiceNumber'] ?? '';
+        $description = $options['description'] ?? '';
+        $reason = $options['reason'] ?? '';
+
+        $refund = new Refund();
+
+        if ($invoiceNumber !== '') {
+            $refund->setInvoiceNumber($invoiceNumber);
+        }
+
+        if ($refundAmount !== '0.00') {
+            $amount = new Amount();
+            $amount->setTotal($refundAmount);
+            $amount->setCurrency($currency);
+
+            $refund->setAmount($amount);
+        }
+
+        if ($description !== '') {
+            $refund->setDescription($description);
+        }
+        if ($reason !== '') {
+            $refund->setReason($reason);
+        }
+
+        return $refund;
+    }
+
+    private function getResourceIdAndTypeToRefund(OrderRefundEntity $orderRefund): array
+    {
+        $salesChannelId = $orderRefund->getOrder()->getSalesChannelId();
+        $capture = $orderRefund->getTransactionCapture();
+        if ($capture !== null) {
+            $resourceId = $capture->getExternalReference();
+            $resourceType = $capture->getCustomFields()[SwagPayPal::ORDER_TRANSACTION_CAPTURE_CUSTOM_FIELDS_PAYPAL_RESOURCE_TYPE] ?? null;
+            if ($resourceId === null || $resourceType === null) {
+                throw new ResourceMissingInCaptureException($capture->getId());
+            }
+
+            return [
+                $resourceId,
+                $resourceType,
+            ];
+        }
+
+        $orderTransaction = $orderRefund->getTransaction();
+        $paymentId = $orderTransaction->getCustomFields()[SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_TRANSACTION_ID];
+        $payment = $this->paymentResource->get($paymentId, $salesChannelId);
+        $relatedResources = $payment->getTransactions()[0]->getRelatedResources();
+        $resourcesAbleToBeRefunded = array_values(array_filter($relatedResources, function (RelatedResource $resource) {
+            $isNonRefundedSale = $resource->getSale() && $resource->getSale()->getState() !== PaymentStatusV1::PAYMENT_SALE_REFUNDED;
+            $isNonRefundedCapture = $resource->getCapture() && $resource->getCapture()->getState() !== PaymentStatusV1::PAYMENT_CAPTURE_REFUNDED;
+
+            return $isNonRefundedSale || $isNonRefundedCapture;
+        }));
+        if (count($resourcesAbleToBeRefunded) === 0) {
+            throw new NoRefundableResourceAvailableException($orderTransaction->getId());
+        }
+
+        $resourceToRefund = $resourcesAbleToBeRefunded[0];
+        $resourceId = $resourceToRefund->getSale() ? $resourceToRefund->getSale()->getId() : $resourceToRefund->getCapture()->getId();
+        $resourceType = $resourceToRefund->getSale() ? RelatedResource::SALE : RelatedResource::CAPTURE;
+
+        return [
+            $resourceId,
+            $resourceType,
+        ];
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,6 +14,7 @@
         <import resource="./services/payments_api.xml"/>
         <import resource="./services/plus.xml"/>
         <import resource="./services/pui_checkout.xml"/>
+        <import resource="./services/refund.xml"/>
         <import resource="./services/resource_v1.xml"/>
         <import resource="./services/resource_v2.xml"/>
         <import resource="./services/service_v1.xml"/>

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -7,7 +7,6 @@
     <services>
         <service id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService">
             <argument type="service" id="order_transaction_capture.repository"/>
-            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
         </service>
 
         <service id="Swag\PayPal\Checkout\CheckoutSubscriber">
@@ -35,6 +34,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
             <tag name="shopware.payment.method.async"/>
         </service>
@@ -60,6 +60,7 @@
             <argument type="service" id="Swag\PayPal\OrdersApi\Patch\CustomIdPatchBuilder"/>
             <argument type="service" id="Swag\PayPal\Util\Logger"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
 
@@ -74,6 +75,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Swag\PayPal\Util\Logger"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
     </services>

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -36,6 +36,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
+            <argument type="service" id="order_transaction_capture.repository"/>
             <tag name="shopware.payment.method.async"/>
         </service>
 
@@ -77,6 +78,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
+            <argument type="service" id="order_transaction_capture.repository"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/checkout.xml
+++ b/src/Resources/config/services/checkout.xml
@@ -5,6 +5,11 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService">
+            <argument type="service" id="order_transaction_capture.repository"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
+        </service>
+
         <service id="Swag\PayPal\Checkout\CheckoutSubscriber">
             <argument type="service" id="Swag\PayPal\Setting\Service\SettingsService"/>
             <argument type="service" id="Swag\PayPal\Util\PaymentMethodUtil"/>
@@ -29,6 +34,8 @@
             <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\PaymentResource"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="order_transaction.repository"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
             <tag name="shopware.payment.method.async"/>
         </service>
 
@@ -52,6 +59,8 @@
             <argument type="service" id="Swag\PayPal\OrdersApi\Patch\OrderNumberPatchBuilder"/>
             <argument type="service" id="Swag\PayPal\OrdersApi\Patch\CustomIdPatchBuilder"/>
             <argument type="service" id="Swag\PayPal\Util\Logger"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
 
         <service id="Swag\PayPal\Checkout\Payment\Handler\PlusPuiHandler">
@@ -64,6 +73,8 @@
             <argument type="service" id="Swag\PayPal\Setting\Service\SettingsService"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Swag\PayPal\Util\Logger"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/orders_api.xml
+++ b/src/Resources/config/services/orders_api.xml
@@ -13,6 +13,8 @@
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Swag\PayPal\Util\PaymentStatusUtilV2"/>
             <argument type="service" id="Swag\PayPal\OrdersApi\Administration\Service\CaptureRefundCreator"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
 
         <service id="Swag\PayPal\OrdersApi\Administration\Service\CaptureRefundCreator">

--- a/src/Resources/config/services/orders_api.xml
+++ b/src/Resources/config/services/orders_api.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="Swag\PayPal\Util\PaymentStatusUtilV2"/>
             <argument type="service" id="Swag\PayPal\OrdersApi\Administration\Service\CaptureRefundCreator"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
 

--- a/src/Resources/config/services/payments_api.xml
+++ b/src/Resources/config/services/payments_api.xml
@@ -17,6 +17,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
+            <argument type="service" id="order_transaction_capture.repository"/>
         </service>
 
         <service id="Swag\PayPal\PaymentsApi\Builder\OrderPaymentBuilder">

--- a/src/Resources/config/services/payments_api.xml
+++ b/src/Resources/config/services/payments_api.xml
@@ -14,6 +14,8 @@
             <argument type="service" id="Swag\PayPal\Util\PaymentStatusUtil"/>
             <argument type="service" id="order.repository"/>
             <argument type="service" id="Swag\PayPal\Util\PriceFormatter"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
 
         <service id="Swag\PayPal\PaymentsApi\Builder\OrderPaymentBuilder">

--- a/src/Resources/config/services/payments_api.xml
+++ b/src/Resources/config/services/payments_api.xml
@@ -15,6 +15,7 @@
             <argument type="service" id="order.repository"/>
             <argument type="service" id="Swag\PayPal\Util\PriceFormatter"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService"/>
             <argument type="service" id="Swag\PayPal\Checkout\PayPalOrderTransactionCaptureService"/>
         </service>
 

--- a/src/Resources/config/services/refund.xml
+++ b/src/Resources/config/services/refund.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Swag\PayPal\Refund\PayPalRefundHandler">
+            <argument type="service" id="order_refund.repository"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\PaymentResource"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\SaleResource"/>
+            <argument type="service" id="Swag\PayPal\RestApi\V1\Resource\CaptureResource"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundStateHandler"/>
+            <tag name="shopware.refund.handler"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services/util.xml
+++ b/src/Resources/config/services/util.xml
@@ -14,12 +14,15 @@
             <argument type="service" id="order.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Swag\PayPal\Util\PriceFormatter"/>
+            <argument type="service" id="order_transaction.repository"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
         </service>
 
         <service id="Swag\PayPal\Util\PaymentStatusUtilV2">
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
             <argument type="service" id="Swag\PayPal\Util\PriceFormatter"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler"/>
         </service>
 
         <service id="Swag\PayPal\Util\PriceFormatter"/>

--- a/src/Resources/config/services/webhook.xml
+++ b/src/Resources/config/services/webhook.xml
@@ -40,6 +40,7 @@
         <service id="Swag\PayPal\Webhook\Handler\CaptureDenied">
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Util\PaymentStatusUtilV2"/>
             <tag name="swag.paypal.webhook.handler"/>
         </service>
 
@@ -62,12 +63,14 @@
         <service id="Swag\PayPal\Webhook\Handler\SaleComplete">
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Util\PaymentStatusUtil"/>
             <tag name="swag.paypal.webhook.handler"/>
         </service>
 
         <service id="Swag\PayPal\Webhook\Handler\SaleDenied">
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Swag\PayPal\Util\PaymentStatusUtil"/>
             <tag name="swag.paypal.webhook.handler"/>
         </service>
 

--- a/src/RestApi/V1/PaymentStatusV1.php
+++ b/src/RestApi/V1/PaymentStatusV1.php
@@ -16,6 +16,11 @@ final class PaymentStatusV1
     public const PAYMENT_PENDING = 'pending';
     public const PAYMENT_PARTIALLY_REFUNDED = 'partially_refunded';
     public const PAYMENT_DENIED = 'denied';
+    public const PAYMENT_CAPTURE_COMPLETED = 'completed';
+    public const PAYMENT_CAPTURE_REFUNDED = 'refunded';
+    public const PAYMENT_SALE_COMPLETED = 'completed';
+    public const PAYMENT_SALE_DENIED = 'denied';
+    public const PAYMENT_SALE_REFUNDED = 'refunded';
 
     private function __construct()
     {

--- a/src/SwagPayPal.php
+++ b/src/SwagPayPal.php
@@ -8,6 +8,7 @@
 namespace Swag\PayPal;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Refund\PaymentMethodRefundConfigService;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
@@ -31,6 +32,7 @@ class SwagPayPal extends Plugin
     public const ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_PUI_INSTRUCTION = 'swag_paypal_pui_payment_instruction';
     public const ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_ORDER_ID = 'swag_paypal_order_id';
     public const ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_PARTNER_ATTRIBUTION_ID = 'swag_paypal_partner_attribution_id';
+    public const ORDER_TRANSACTION_CAPTURE_CUSTOM_FIELDS_PAYPAL_RESOURCE_TYPE = 'swag_paypal_resource_type';
     public const SALES_CHANNEL_TYPE_POS = '1ce0868f406d47d98cfe4b281e62f099';
     public const SALES_CHANNEL_POS_EXTENSION = 'paypalPosSalesChannel';
     public const PRODUCT_LOG_POS_EXTENSION = 'paypalPosLog';
@@ -91,6 +93,8 @@ class SwagPayPal extends Plugin
         $systemConfigService = $this->container->get(SystemConfigService::class);
         /** @var Connection $connection */
         $connection = $this->container->get(Connection::class);
+        /** @var PaymentMethodRefundConfigService $paymentMethodRefundConfigService */
+        $paymentMethodRefundConfigService = $this->container->get(PaymentMethodRefundConfigService::class);
 
         (new InstallUninstall(
             $systemConfigRepository,
@@ -101,6 +105,7 @@ class SwagPayPal extends Plugin
             $pluginIdProvider,
             $systemConfigService,
             $connection,
+            $paymentMethodRefundConfigService,
             static::class
         ))->install($installContext->getContext());
 
@@ -133,6 +138,8 @@ class SwagPayPal extends Plugin
         $systemConfigService = $this->container->get(SystemConfigService::class);
         /** @var Connection $connection */
         $connection = $this->container->get(Connection::class);
+        /** @var PaymentMethodRefundConfigService $paymentMethodRefundConfigService */
+        $paymentMethodRefundConfigService = $this->container->get(PaymentMethodRefundConfigService::class);
 
         (new InstallUninstall(
             $systemConfigRepository,
@@ -143,6 +150,7 @@ class SwagPayPal extends Plugin
             $pluginIdProvider,
             $systemConfigService,
             $connection,
+            $paymentMethodRefundConfigService,
             static::class
         ))->uninstall($context);
 
@@ -161,13 +169,16 @@ class SwagPayPal extends Plugin
         $webhookService = $this->container->get(WebhookService::class, ContainerInterface::NULL_ON_INVALID_REFERENCE);
         /** @var EntityRepositoryInterface $salesChannelRepository */
         $salesChannelRepository = $this->container->get('sales_channel.repository');
+        /** @var PaymentMethodRefundConfigService $paymentMethodRefundConfigService */
+        $paymentMethodRefundConfigService = $this->container->get(PaymentMethodRefundConfigService::class);
 
         (new Update(
             $systemConfigService,
             $paymentRepository,
             $customFieldRepository,
             $webhookService,
-            $salesChannelRepository
+            $salesChannelRepository,
+            $paymentMethodRefundConfigService,
         ))->update($updateContext);
 
         $this->addCustomPrivileges();

--- a/src/Webhook/Handler/SaleComplete.php
+++ b/src/Webhook/Handler/SaleComplete.php
@@ -7,13 +7,30 @@
 
 namespace Swag\PayPal\Webhook\Handler;
 
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Swag\PayPal\RestApi\PayPalApiStruct;
 use Swag\PayPal\RestApi\V1\Api\Webhook as WebhookV1;
+use Swag\PayPal\Util\PaymentStatusUtil;
 use Swag\PayPal\Webhook\WebhookEventTypes;
 
 class SaleComplete extends AbstractWebhookHandler
 {
+    /**
+     * @var PaymentStatusUtil
+     */
+    private $paymentStatusUtil;
+
+    public function __construct(
+        EntityRepositoryInterface $orderTransactionRepository,
+        OrderTransactionStateHandler $orderTransactionStateHandler,
+        PaymentStatusUtil $paymentStatusUtil
+    ) {
+        parent::__construct($orderTransactionRepository, $orderTransactionStateHandler);
+        $this->paymentStatusUtil = $paymentStatusUtil;
+    }
+
     public function getEventType(): string
     {
         return WebhookEventTypes::PAYMENT_SALE_COMPLETED;
@@ -25,6 +42,12 @@ class SaleComplete extends AbstractWebhookHandler
     public function invoke(PayPalApiStruct $webhook, Context $context): void
     {
         $orderTransaction = $this->getOrderTransaction($webhook, $context);
+
+        $this->paymentStatusUtil->applySaleStateToOrderTransactionCapture(
+            $orderTransaction->getId(),
+            $webhook->getResource(),
+            $context
+        );
 
         $this->orderTransactionStateHandler->paid($orderTransaction->getId(), $context);
     }

--- a/src/Webhook/Handler/SaleDenied.php
+++ b/src/Webhook/Handler/SaleDenied.php
@@ -7,13 +7,30 @@
 
 namespace Swag\PayPal\Webhook\Handler;
 
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Swag\PayPal\RestApi\PayPalApiStruct;
 use Swag\PayPal\RestApi\V1\Api\Webhook as WebhookV1;
+use Swag\PayPal\Util\PaymentStatusUtil;
 use Swag\PayPal\Webhook\WebhookEventTypes;
 
 class SaleDenied extends AbstractWebhookHandler
 {
+    /**
+     * @var PaymentStatusUtil
+     */
+    private $paymentStatusUtil;
+
+    public function __construct(
+        EntityRepositoryInterface $orderTransactionRepository,
+        OrderTransactionStateHandler $orderTransactionStateHandler,
+        PaymentStatusUtil $paymentStatusUtil
+    ) {
+        parent::__construct($orderTransactionRepository, $orderTransactionStateHandler);
+        $this->paymentStatusUtil = $paymentStatusUtil;
+    }
+
     public function getEventType(): string
     {
         return WebhookEventTypes::PAYMENT_SALE_DENIED;
@@ -25,6 +42,12 @@ class SaleDenied extends AbstractWebhookHandler
     public function invoke(PayPalApiStruct $webhook, Context $context): void
     {
         $orderTransaction = $this->getOrderTransaction($webhook, $context);
+
+        $this->paymentStatusUtil->applySaleStateToOrderTransactionCapture(
+            $orderTransaction->getId(),
+            $webhook->getResource(),
+            $context
+        );
 
         $this->orderTransactionStateHandler->cancel($orderTransaction->getId(), $context);
     }


### PR DESCRIPTION
This PR adds a payment refund handler to the paypal payment method. This allows payments created with order transaction captures to be refunded through Shopware.

This is companion PR to the Shopware PR which adds support for refunding through Shopware: https://github.com/shopware/platform/pull/1589
Because this is a preliminary version of the PR, it does not have tests yet.