### PR TITLE
Fix tax issue for net mode and discount

### DIFF
--- a/src/OrdersApi/Builder/Util/AmountProvider.php
+++ b/src/OrdersApi/Builder/Util/AmountProvider.php
@@ -76,11 +76,15 @@ class AmountProvider
     ): Breakdown {
         $accumulatedAmountValue = 0.0;
         $newItems = [];
+        $taxesCorrection = 0.0;
+
         foreach ($items as $item) {
             $itemUnitAmount = (float) $item->getUnitAmount()->getValue();
             if ($itemUnitAmount >= 0.0) {
                 $accumulatedAmountValue += $item->getQuantity() * $itemUnitAmount;
                 $newItems[] = $item;
+            } else {
+                $taxesCorrection += (float) $item->getTax()->getValue();
             }
         }
         $purchaseUnit->setItems($newItems);
@@ -98,7 +102,7 @@ class AmountProvider
         $taxTotal->setCurrencyCode($currencyCode);
         if ($isNet) {
             $taxTotal->setValue($this->priceFormatter->formatPrice(
-                $taxes->getAmount() - $shippingCosts->getCalculatedTaxes()->getAmount()
+                $taxes->getAmount() - ($shippingCosts->getCalculatedTaxes()->getAmount() + $taxesCorrection)
             ));
         } else {
             $taxTotal->setValue($this->priceFormatter->formatPrice(0.0));


### PR DESCRIPTION
I an user has a discount and is in net mode the tax calculation is wrong because negative items will be removed but the taxes aren't taken into account. So we need to correct the total tax amount.