### PR TITLE
Respect plugin settings in buy-widget-form

### DIFF
--- a/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
+++ b/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
@@ -39,7 +39,7 @@
                 {# @var \Swag\PayPal\Installment\Banner\BannerData installmentBanner #}
                 {% set installmentBanner = page.extensions[constant('Swag\\PayPal\\Installment\\Banner\\InstallmentBannerSubscriber::PAYPAL_INSTALLMENT_BANNER_DATA_EXTENSION_ID')] %}
 
-                {% if installmentBanner is not null %}
+                {% if installmentBanner is not null and installmentBanner.detailPageEnabled %}
                     <div class="{{ isBootstrap5 ? 'row g-2 mt-0' : 'form-row mt-3' }} mb-4 justify-content-end">
                         <div class="{{ buyable ? 'col-8' : 'col-12' }}"
                              data-swag-paypal-installment-banner="true"


### PR DESCRIPTION
After the update from 7.2.4 to 7.3.0 on the product detail pages an text apperead "PayPal Bezahlen Sie in 3-24 monatlichen Raten. Mehr erfahren"


This changes makes sure the plugin setting "'Direkt zu PayPal' auf Detailseite" is respected.