### PR TITLE
fix(storefront): re-render PayPal buttons after browser Back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue, where a custom tax provider's adjusted total was not charged, because the PayPal order used the stale cart or order transaction amount instead of the taxed total (shopware/SwagPayPal#722)
+- Fixes an issue, where PayPal Express Checkout buttons disappeared after using the browser back button from the checkout page (shopware/shopware#18297)
 
 # 10.8.0
 - Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem der von einem benutzerdefinierten Tax Provider angepasste Gesamtbetrag nicht berechnet wurde, weil die PayPal-Bestellung den veralteten Warenkorb- oder Bestelltransaktionsbetrag anstelle des besteuerten Gesamtbetrags verwendete (shopware/SwagPayPal#722)
+- Behebt ein Problem, bei dem die PayPal Express Checkout Buttons nach dem Zurücknavigieren vom Checkout mit dem Browser-Zurück-Button nicht mehr angezeigt wurden (shopware/shopware#18297)
 
 # 10.8.0
 - Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.abstract-standalone.js
@@ -57,18 +57,28 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
 
     init() {
         this.confirmOrderForm = DomAccess.querySelector(document, this.options.confirmOrderFormSelector);
+        this._paypalButton = null;
 
         if (this.options.preventErrorReload) {
             DomAccess.querySelector(this.confirmOrderForm, this.options.confirmOrderButtonSelector).disabled = 'disabled';
 
             return;
-        } else {
-            ElementLoadingIndicatorUtil.create(this.el);
         }
 
         DomAccess.querySelector(this.confirmOrderForm, this.options.confirmOrderButtonSelector).classList.add('d-none');
 
         this._client = new HttpClient();
+
+        this._createPayPalButton();
+    }
+
+    /**
+     * Creates / re-creates the PayPal button without re-applying confirm-form UI setup.
+     *
+     * @private
+     */
+    _createPayPalButton() {
+        ElementLoadingIndicatorUtil.create(this.el);
 
         this.createScript(async (paypal) => {
             // catch sync and async errors - `.catch()` or similar aren't able to do so
@@ -88,7 +98,34 @@ export default class SwagPaypalAbstractStandalone extends SwagPaypalAbstractButt
             return void this.handleError(this.NOT_ELIGIBLE, true, `Funding for PayPal button is not eligible (${this.getFundingSource(paypal)})`);
         }
 
-        button.render(this.el);
+        this._paypalButton = button;
+
+        return button.render(this.el);
+    }
+
+    onBfcacheRestore() {
+        if (this.options.preventErrorReload) {
+            return;
+        }
+
+        this._closePayPalButton();
+        this.el.replaceChildren();
+        this._createPayPalButton();
+    }
+
+    /**
+     * @private
+     */
+    _closePayPalButton() {
+        if (this._paypalButton && typeof this._paypalButton.close === 'function') {
+            try {
+                this._paypalButton.close();
+            } catch {
+                // button may already be torn down after bfcache restore
+            }
+        }
+
+        this._paypalButton = null;
     }
 
     /**

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.acdc-fields.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.acdc-fields.js
@@ -100,6 +100,7 @@ export default class SwagPaypalAcdcFields extends SwagPaypalAbstractStandalone {
                 return void this.handleError(this.NOT_ELIGIBLE, true, 'Neither hosted fields nor standalone buttons are eligible');
             }
 
+            this._paypalButton = button;
             button.render(this.el);
         }
     }

--- a/src/Resources/app/storefront/src/checkout/swag-paypal.smart-payment-buttons.js
+++ b/src/Resources/app/storefront/src/checkout/swag-paypal.smart-payment-buttons.js
@@ -14,6 +14,8 @@ export default class SwagPayPalSmartPaymentButtons extends SwagPaypalAbstractSta
             return void this.handleError(this.NOT_ELIGIBLE, true, `Funding for PayPal button is not eligible (${this.getFundingSource(paypal)})`);
         }
 
+        this._paypalButton = button;
+
         if (this.options.appSwitchEnabled && typeof button.hasReturned === 'function' && button.hasReturned()) {
             return button.resume();
         }

--- a/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
+++ b/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
@@ -105,6 +105,7 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
 
     init() {
         this._client = new HttpClient();
+        this._paypalButtons = [];
         this.createButton();
     }
 
@@ -124,13 +125,36 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
                 const button = paypal.Buttons(this.getButtonConfig(fundingSource));
 
                 if (button.isEligible()) {
+                    this._paypalButtons.push(button);
                     button.render(this.el);
                 }
             } catch (e) {
                 this.handleError(this.SCRIPT_ERROR, true, `Error while rendering express button for "${fundingSource}": ${e}`);
             }
         });
+    }
 
+    onBfcacheRestore() {
+        this._closePayPalButtons();
+        this.el.replaceChildren();
+        this.createButton();
+    }
+
+    /**
+     * @private
+     */
+    _closePayPalButtons() {
+        this._paypalButtons.forEach((button) => {
+            if (typeof button.close === 'function') {
+                try {
+                    button.close();
+                } catch {
+                    // button may already be torn down after bfcache restore
+                }
+            }
+        });
+
+        this._paypalButtons = [];
     }
 
     getBuyButtonState() {

--- a/src/Resources/app/storefront/src/page/swag-paypal.installment-banner.js
+++ b/src/Resources/app/storefront/src/page/swag-paypal.installment-banner.js
@@ -104,6 +104,11 @@ export default class SwagPayPalInstallmentBanner extends SwagPayPalScriptBase {
         });
     }
 
+    onBfcacheRestore() {
+        this.el.replaceChildren();
+        this.createInstallmentBanner();
+    }
+
     getBannerConfig() {
         return {
             amount: this.options.amount,

--- a/src/Resources/app/storefront/src/swag-paypal.script-base.js
+++ b/src/Resources/app/storefront/src/swag-paypal.script-base.js
@@ -124,6 +124,8 @@ export default class SwagPayPalScriptBase extends Plugin {
     static paypal = {};
 
     _init() {
+        this._bindBfcacheRestore();
+
         if (this.options.partOfDomContentLoading || document.readyState === 'complete') {
             super._init();
         } else {
@@ -131,6 +133,47 @@ export default class SwagPayPalScriptBase extends Plugin {
                 super._init();
             });
         }
+    }
+
+    /**
+     * PayPal widgets render into iframes that do not survive bfcache restores
+     * (browser Back/Forward). Re-render when the page is restored from bfcache.
+     *
+     * @private
+     */
+    _bindBfcacheRestore() {
+        if (this._bfcacheBound) {
+            return;
+        }
+
+        this._bfcacheBound = true;
+        this._onPageShow = (event) => {
+            if (!event.persisted) {
+                return;
+            }
+
+            this.onBfcacheRestore();
+        };
+
+        window.addEventListener('pageshow', this._onPageShow);
+    }
+
+    /**
+     * Re-render PayPal UI after the page was restored from bfcache.
+     * Override in subclasses that render into this.el.
+     */
+    onBfcacheRestore() {
+        // no-op by default
+    }
+
+    destroy() {
+        if (this._onPageShow) {
+            window.removeEventListener('pageshow', this._onPageShow);
+            this._onPageShow = null;
+            this._bfcacheBound = false;
+        }
+
+        super.destroy();
     }
 
     get scriptOptionsHash() {

--- a/tests/Checkout/SalesChannel/CustomerVaultTokenRouteTest.php
+++ b/tests/Checkout/SalesChannel/CustomerVaultTokenRouteTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\PayPalSDK\Struct\V1\Token;
@@ -63,7 +64,10 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->tokenResource->expects($this->once())->method('getUserIdToken')->willReturn($token);
 
-        $response = $this->createRoute(new VaultTokenCollection([new VaultTokenEntity()]))
+        $vaultToken = new VaultTokenEntity();
+        $vaultToken->setId(Uuid::randomHex());
+
+        $response = $this->createRoute(new VaultTokenCollection([$vaultToken]))
             ->getVaultToken($salesChannelContext);
 
         static::assertSame(
@@ -84,7 +88,10 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->expectException(MissingCustomerVaultTokenException::class);
 
-        $this->createRoute(new VaultTokenCollection([new VaultTokenEntity()]))
+        $vaultToken = new VaultTokenEntity();
+        $vaultToken->setId(Uuid::randomHex());
+
+        $this->createRoute(new VaultTokenCollection([$vaultToken]))
             ->getVaultToken($salesChannelContext);
     }
 

--- a/tests/Checkout/SalesChannel/CustomerVaultTokenRouteTest.php
+++ b/tests/Checkout/SalesChannel/CustomerVaultTokenRouteTest.php
@@ -29,9 +29,19 @@ class CustomerVaultTokenRouteTest extends TestCase
 {
     private TokenResourceInterface&MockObject $tokenResource;
 
+    /**
+     * @var StaticEntityRepository<VaultTokenCollection>
+     */
+    private StaticEntityRepository $repository;
+
+    private CustomerVaultTokenRoute $route;
+
     protected function setUp(): void
     {
         $this->tokenResource = $this->createMock(TokenResourceInterface::class);
+        $this->repository = new StaticEntityRepository([]);
+
+        $this->route = new CustomerVaultTokenRoute($this->repository, $this->tokenResource);
     }
 
     public function testGetVaultTokenWithoutCustomer(): void
@@ -41,7 +51,7 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->expectException(CustomerException::class);
 
-        $this->createRoute()->getVaultToken($salesChannelContext);
+        $this->route->getVaultToken($salesChannelContext);
     }
 
     public function testGetVaultTokenWithGuestCustomer(): void
@@ -51,7 +61,7 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->expectException(CustomerException::class);
 
-        $this->createRoute()->getVaultToken($salesChannelContext);
+        $this->route->getVaultToken($salesChannelContext);
     }
 
     public function testGetVaultToken(): void
@@ -66,9 +76,9 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $vaultToken = new VaultTokenEntity();
         $vaultToken->setId(Uuid::randomHex());
+        $this->repository->addSearch(new VaultTokenCollection([$vaultToken]));
 
-        $response = $this->createRoute(new VaultTokenCollection([$vaultToken]))
-            ->getVaultToken($salesChannelContext);
+        $response = $this->route->getVaultToken($salesChannelContext);
 
         static::assertSame(
             $token->getIdToken(),
@@ -86,22 +96,12 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->tokenResource->expects($this->once())->method('getUserIdToken')->willReturn($token);
 
-        $this->expectException(MissingCustomerVaultTokenException::class);
-
         $vaultToken = new VaultTokenEntity();
         $vaultToken->setId(Uuid::randomHex());
+        $this->repository->addSearch(new VaultTokenCollection([$vaultToken]));
 
-        $this->createRoute(new VaultTokenCollection([$vaultToken]))
-            ->getVaultToken($salesChannelContext);
-    }
+        $this->expectException(MissingCustomerVaultTokenException::class);
 
-    private function createRoute(?VaultTokenCollection $tokens = null): CustomerVaultTokenRoute
-    {
-        $searches = $tokens !== null ? [$tokens] : [];
-
-        return new CustomerVaultTokenRoute(
-            new StaticEntityRepository($searches),
-            $this->tokenResource,
-        );
+        $this->route->getVaultToken($salesChannelContext);
     }
 }

--- a/tests/Checkout/SalesChannel/CustomerVaultTokenRouteTest.php
+++ b/tests/Checkout/SalesChannel/CustomerVaultTokenRouteTest.php
@@ -10,13 +10,13 @@ namespace Swag\PayPal\Test\Checkout\SalesChannel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerException;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\PayPalSDK\Struct\V1\Token;
 use Swag\PayPal\Checkout\Exception\MissingCustomerVaultTokenException;
 use Swag\PayPal\Checkout\SalesChannel\CustomerVaultTokenRoute;
+use Swag\PayPal\DataAbstractionLayer\VaultToken\VaultTokenCollection;
 use Swag\PayPal\DataAbstractionLayer\VaultToken\VaultTokenEntity;
 use Swag\PayPal\RestApi\V1\Resource\TokenResourceInterface;
 
@@ -26,18 +26,11 @@ use Swag\PayPal\RestApi\V1\Resource\TokenResourceInterface;
 #[Package('checkout')]
 class CustomerVaultTokenRouteTest extends TestCase
 {
-    private EntityRepository&MockObject $repository;
-
     private TokenResourceInterface&MockObject $tokenResource;
-
-    private CustomerVaultTokenRoute $route;
 
     protected function setUp(): void
     {
-        $this->repository = $this->createMock(EntityRepository::class);
         $this->tokenResource = $this->createMock(TokenResourceInterface::class);
-
-        $this->route = new CustomerVaultTokenRoute($this->repository, $this->tokenResource);
     }
 
     public function testGetVaultTokenWithoutCustomer(): void
@@ -47,7 +40,7 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->expectException(CustomerException::class);
 
-        $this->route->getVaultToken($salesChannelContext);
+        $this->createRoute()->getVaultToken($salesChannelContext);
     }
 
     public function testGetVaultTokenWithGuestCustomer(): void
@@ -57,7 +50,7 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->expectException(CustomerException::class);
 
-        $this->route->getVaultToken($salesChannelContext);
+        $this->createRoute()->getVaultToken($salesChannelContext);
     }
 
     public function testGetVaultToken(): void
@@ -65,16 +58,13 @@ class CustomerVaultTokenRouteTest extends TestCase
         $salesChannelContext = Generator::generateSalesChannelContext();
         $salesChannelContext->getCustomer()?->setGuest(false);
 
-        $entitySearchResult = $this->createMock(EntitySearchResult::class);
-        $this->repository->expects($this->once())->method('search')->willReturn($entitySearchResult);
-        $entitySearchResult->expects($this->once())->method('first')->willReturn(new VaultTokenEntity());
-
         $token = new Token();
         $token->assign(['idToken' => 'dummy-token', 'expiresIn' => 45000]);
 
         $this->tokenResource->expects($this->once())->method('getUserIdToken')->willReturn($token);
 
-        $response = $this->route->getVaultToken($salesChannelContext);
+        $response = $this->createRoute(new VaultTokenCollection([new VaultTokenEntity()]))
+            ->getVaultToken($salesChannelContext);
 
         static::assertSame(
             $token->getIdToken(),
@@ -87,10 +77,6 @@ class CustomerVaultTokenRouteTest extends TestCase
         $salesChannelContext = Generator::generateSalesChannelContext();
         $salesChannelContext->getCustomer()?->setGuest(false);
 
-        $entitySearchResult = $this->createMock(EntitySearchResult::class);
-        $this->repository->expects($this->once())->method('search')->willReturn($entitySearchResult);
-        $entitySearchResult->expects($this->once())->method('first')->willReturn(new VaultTokenEntity());
-
         $token = new Token();
         $token->assign(['idToken' => null, 'expiresIn' => 45000]);
 
@@ -98,6 +84,17 @@ class CustomerVaultTokenRouteTest extends TestCase
 
         $this->expectException(MissingCustomerVaultTokenException::class);
 
-        $this->route->getVaultToken($salesChannelContext);
+        $this->createRoute(new VaultTokenCollection([new VaultTokenEntity()]))
+            ->getVaultToken($salesChannelContext);
+    }
+
+    private function createRoute(?VaultTokenCollection $tokens = null): CustomerVaultTokenRoute
+    {
+        $searches = $tokens !== null ? [$tokens] : [];
+
+        return new CustomerVaultTokenRoute(
+            new StaticEntityRepository($searches),
+            $this->tokenResource,
+        );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Browser Back restores the product/listing page from bfcache. PayPal buttons live in iframes that don’t survive that restore, so Express buttons look hidden until a full reload.

### 2. What does this change do, exactly?
On bfcache restore (`pageshow` with `event.persisted`), it closes existing PayPal widgets clears the mount nodes and re-renders Express buttons.

### 3. Describe each step to reproduce the issue or behaviour.
1. On Storefront, Click **Add to shopping cart** button on any product
2. Add the some other products to cart by clicking on **PayPal checkout** button on any products
3. Expect the PayPal popup displayed and loading, close it before it fully load
4. The Off canvas cart is now displayed with error > Click **Go to checkout** button 
5. At checkout page, click **Back** button on the browser

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/shopware/issues/18297

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
