### PR TITLE
fix: handle PayPal transport errors and clear Express spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue, where a custom tax provider's adjusted total was not charged, because the PayPal order used the stale cart or order transaction amount instead of the taxed total (shopware/SwagPayPal#722)
 - Fixes an issue, where PayPal shipping tracking sync retried 429 RATE_LIMIT_REACHED responses too early instead of respecting the Retry-After header.
+- Fixes an issue, where transient PayPal API transport errors during Express Checkout resulted in HTTP 500 and left the loading spinner stuck on the page
 
 # 10.8.0
 - Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem der von einem benutzerdefinierten Tax Provider angepasste Gesamtbetrag nicht berechnet wurde, weil die PayPal-Bestellung den veralteten Warenkorb- oder Bestelltransaktionsbetrag anstelle des besteuerten Gesamtbetrags verwendete (shopware/SwagPayPal#722)
 - Behebt ein Problem, bei dem die PayPal-Versandtracking-Synchronisierung 429 RATE_LIMIT_REACHED-Antworten zu früh erneut verarbeitet hat, anstatt den Retry-After-Header zu berücksichtigen.
+- Behebt ein Problem, bei dem vorübergehende PayPal-API-Transportfehler während des Express Checkouts zu HTTP 500 führten und der Ladeindikator auf der Seite stecken blieb
 
 # 10.8.0
 - Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)

--- a/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
+++ b/src/Resources/app/storefront/src/page/swag-paypal.express-checkout.js
@@ -330,7 +330,11 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
             (response, request) => {
                 if (request.status < 400) {
                     return actions.redirect(this.options.checkoutConfirmUrl);
-                } else if (request.status === 400) {
+                }
+
+                ElementLoadingIndicatorUtil.remove(document.body);
+
+                if (request.status === 400) {
                     try {
                         this.onError(JSON.parse(request.response));
                     } catch (error) {
@@ -338,7 +342,7 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
                         this.onError();
                     }
 
-                    return window.location.reload();
+                    return;
                 }
 
                 return this.onError();
@@ -347,6 +351,8 @@ export default class SwagPayPalExpressCheckoutButton extends SwagPaypalAbstractB
     }
 
     onErrorHandled(code, fatal, error, isCheckout = false) {
+        ElementLoadingIndicatorUtil.remove(document.body);
+
         if (code === this.USER_CANCELLED) {
             window.scrollTo(0, 0);
             window.location = this.options.cancelRedirectUrl;

--- a/src/Resources/config/packages/framework.yaml
+++ b/src/Resources/config/packages/framework.yaml
@@ -18,3 +18,13 @@ framework:
       paypal.base-client:
         scope: https\://api\-m\.(sandbox\.)?paypal\.com/
         max_duration: 30
+        retry_failed:
+          max_retries: 3
+          delay: 1000
+          multiplier: 2
+          jitter: 0.1
+          http_codes:
+            0: ['GET', 'HEAD', 'OPTIONS']
+            429: ['GET', 'HEAD', 'OPTIONS']
+            502: ['GET', 'HEAD', 'OPTIONS']
+            503: ['GET', 'HEAD', 'OPTIONS']

--- a/src/Resources/config/packages/framework.yaml
+++ b/src/Resources/config/packages/framework.yaml
@@ -20,8 +20,9 @@ framework:
         max_duration: 30
         retry_failed:
           max_retries: 3
-          delay: 1000
+          delay: 200
           multiplier: 2
+          max_delay: 1000
           jitter: 0.1
           http_codes:
             0: ['GET', 'HEAD', 'OPTIONS']

--- a/src/RestApi/Client/Client.php
+++ b/src/RestApi/Client/Client.php
@@ -7,12 +7,14 @@
 
 namespace Swag\PayPal\RestApi\Client;
 
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Log\Package;
+use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Symfony\Component\HttpClient\Psr18Client;
 
 #[Package('checkout')]
@@ -33,9 +35,27 @@ class Client implements ClientInterface
     ) {
     }
 
+    /**
+     * @throws PayPalApiException
+     */
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
-        $response = $this->client->sendRequest($request);
+        try {
+            $response = $this->client->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            $this->logger->error(
+                'PayPal network error: {message}',
+                [
+                    'message' => $e->getMessage(),
+                    'method' => \mb_strtoupper($request->getMethod()),
+                    'target' => (string) $request->getUri(),
+                    'requestId' => $request->getHeaderLine('paypal-request-id') ?: null,
+                    'error' => $e,
+                ],
+            );
+
+            throw PayPalApiException::fromClientException($e);
+        }
 
         if ($response->getStatusCode() >= 400) {
             $this->logger->error(

--- a/src/RestApi/Exception/PayPalApiException.php
+++ b/src/RestApi/Exception/PayPalApiException.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\RestApi\Exception;
 
+use Psr\Http\Client\ClientExceptionInterface;
 use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Exception\ApiException;
@@ -25,6 +26,7 @@ class PayPalApiException extends PaymentException
     public const ISSUE_DUPLICATE_INVOICE_ID = 'DUPLICATE_INVOICE_ID';
     public const ISSUE_INVALID_PARAMETER_VALUE = 'INVALID_PARAMETER_VALUE';
     public const ISSUE_INVALID_RESOURCE_ID = 'INVALID_RESOURCE_ID';
+    public const ISSUE_NETWORK_ERROR = 'NETWORK_ERROR';
 
     private readonly ?\DateTimeImmutable $retryAt;
 
@@ -96,6 +98,16 @@ class PayPalApiException extends PaymentException
             $e->getStatusCode(),
             $issue,
             $e instanceof RetryAfterApiException ? $e->getRetryAt() : null,
+        );
+    }
+
+    public static function fromClientException(ClientExceptionInterface $e): self
+    {
+        return new self(
+            'SERVICE_UNAVAILABLE',
+            'PayPal is currently unreachable. Please try again later.',
+            Response::HTTP_BAD_GATEWAY,
+            self::ISSUE_NETWORK_ERROR,
         );
     }
 

--- a/tests/RestApi/Client/ClientTest.php
+++ b/tests/RestApi/Client/ClientTest.php
@@ -16,8 +16,13 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
 use Shopware\Core\Framework\Log\Package;
 use Swag\PayPal\RestApi\Client\Client;
+use Swag\PayPal\RestApi\Exception\PayPalApiException;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
 /**
  * @internal
@@ -131,5 +136,54 @@ class ClientTest extends TestCase
             'debugId' => '',
             'requestId' => '1234567',
         ], $logs[0]->context);
+    }
+
+    public function testSendRequestWrapsNetworkException(): void
+    {
+        $request = new Request('GET', 'https://api-m.paypal.com/v2/checkout/orders/ORDER-ID', [
+            'paypal-request-id' => 'req-1',
+        ]);
+
+        $networkException = new class($request) extends \RuntimeException implements NetworkExceptionInterface {
+            public function __construct(private readonly RequestInterface $request)
+            {
+                parent::__construct('Could not resolve host: api-m.paypal.com');
+            }
+
+            public function getRequest(): RequestInterface
+            {
+                return $this->request;
+            }
+        };
+
+        $innerClient = $this->createMock(ClientInterface::class);
+        $innerClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($request)
+            ->willThrowException($networkException);
+
+        $client = new Client(
+            new Logger('test', [$this->logger]),
+            $innerClient,
+        );
+
+        try {
+            $client->sendRequest($request);
+            static::fail('Expected PayPalApiException to be thrown');
+        } catch (PayPalApiException $exception) {
+            static::assertSame(HttpResponse::HTTP_BAD_GATEWAY, $exception->getStatusCode());
+            static::assertTrue($exception->is(PayPalApiException::ISSUE_NETWORK_ERROR));
+            static::assertTrue($exception->is('SERVICE_UNAVAILABLE'));
+            static::assertSame('SWAG_PAYPAL__API_NETWORK_ERROR', $exception->getErrorCode());
+        }
+
+        $logs = $this->logger->getRecords();
+        static::assertCount(1, $logs);
+        static::assertSame('PayPal network error: {message}', $logs[0]->message);
+        static::assertSame('Could not resolve host: api-m.paypal.com', $logs[0]->context['message']);
+        static::assertSame('GET', $logs[0]->context['method']);
+        static::assertSame('https://api-m.paypal.com/v2/checkout/orders/ORDER-ID', $logs[0]->context['target']);
+        static::assertSame('req-1', $logs[0]->context['requestId']);
     }
 }

--- a/tests/RestApi/Exception/PayPalApiExceptionTest.php
+++ b/tests/RestApi/Exception/PayPalApiExceptionTest.php
@@ -9,10 +9,13 @@ namespace Swag\PayPal\Test\RestApi\Exception;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Exception\RetryAfterApiException;
 use Shopware\PayPalSDK\Struct\Error\DetailCollection;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -58,5 +61,31 @@ class PayPalApiExceptionTest extends TestCase
 
         static::assertTrue($exception->is('RATE_LIMIT_REACHED'));
         static::assertSame($retryAt, $exception->getRetryAt());
+    }
+
+    public function testFromClientException(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+
+        $networkException = new class($request) extends \RuntimeException implements NetworkExceptionInterface {
+            public function __construct(private readonly RequestInterface $request)
+            {
+                parent::__construct('Could not resolve host: api-m.paypal.com');
+            }
+
+            public function getRequest(): RequestInterface
+            {
+                return $this->request;
+            }
+        };
+
+        $exception = PayPalApiException::fromClientException($networkException);
+
+        static::assertSame(Response::HTTP_BAD_GATEWAY, $exception->getStatusCode());
+        static::assertTrue($exception->is(PayPalApiException::ISSUE_NETWORK_ERROR));
+        static::assertTrue($exception->is('SERVICE_UNAVAILABLE'));
+        static::assertSame('SWAG_PAYPAL__API_NETWORK_ERROR', $exception->getErrorCode());
+        static::assertStringContainsString('PayPal is currently unreachable', $exception->getMessage());
+        static::assertNull($exception->getRetryAt());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Transient PayPal API transport failures (e.g. short DNS outages) during Express `prepare-checkout` currently surface as HTTP 500, and the Express loading spinner is never cleared on the error path, leaving buyers stuck with no recovery.

### 2. What does this change do, exactly?
- Maps `ClientExceptionInterface` to a customer-facing `PayPalApiException` (502 / `NETWORK_ERROR`) instead of an unhandled 500
- Enables method-restricted HTTP retries on `paypal.base-client` for idempotent GETs
- Removes the Express body loading spinner on `onApprove` / error handling failure paths

### 3. Describe each step to reproduce the issue or behaviour.
1. Product page -> Express -> approve in PayPal  
2. Force `POST /paypal/express/prepare-checkout` to 500 (DevTools)  
3. Page stays blocked with spinner  

Same flow with DNS/connect failure to `api-m.paypal.com` -> unhandled 500 from `Client.php`.

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/SwagPayPal/issues/770

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
