### PR TITLE
fix: use plugin-owned configure snippet in extension card context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue, where a custom tax provider's adjusted total was not charged, because the PayPal order used the stale cart or order transaction amount instead of the taxed total (shopware/SwagPayPal#722)
 - Fixes an issue, where PayPal shipping tracking sync retried 429 RATE_LIMIT_REACHED responses too early instead of respecting the Retry-After header.
+- Fixes an issue, where the extension card context menu showed a raw snippet key instead of "Configure" (shopware/shopware#19028)
 
 # 10.8.0
 - Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,6 +1,7 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem der von einem benutzerdefinierten Tax Provider angepasste Gesamtbetrag nicht berechnet wurde, weil die PayPal-Bestellung den veralteten Warenkorb- oder Bestelltransaktionsbetrag anstelle des besteuerten Gesamtbetrags verwendete (shopware/SwagPayPal#722)
 - Behebt ein Problem, bei dem die PayPal-Versandtracking-Synchronisierung 429 RATE_LIMIT_REACHED-Antworten zu früh erneut verarbeitet hat, anstatt den Retry-After-Header zu berücksichtigen.
+- Behebt ein Problem, bei dem im Kontextmenü der Erweiterungs-Kachel der rohe Snippet-Key statt „Konfigurieren” angezeigt wurde (shopware/shopware#19028)
 
 # 10.8.0
 - Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)

--- a/src/Resources/app/administration/src/module/extension/snippet/de.json
+++ b/src/Resources/app/administration/src/module/extension/snippet/de.json
@@ -1,6 +1,7 @@
 {
   "swag-paypal": {
     "extension-card-base": {
+      "config": "Konfigurieren",
       "reportIssue": "Problem melden"
     }
   }

--- a/src/Resources/app/administration/src/module/extension/snippet/en.json
+++ b/src/Resources/app/administration/src/module/extension/snippet/en.json
@@ -1,6 +1,7 @@
 {
   "swag-paypal": {
     "extension-card-base": {
+      "config": "Configure",
       "reportIssue": "Report Issue"
     }
   }

--- a/src/Resources/app/administration/src/module/extension/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Resources/app/administration/src/module/extension/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -10,7 +10,7 @@
         v-if="extension?.name === 'SwagPayPal'"
         :router-link="{ name: 'swag.paypal.settings.index' }"
     >
-        {{ $t('sw-extension-store.component.sw-extension-card-base.contextMenu.config') }}
+        {{ $t('swag-paypal.extension-card-base.config') }}
     </sw-context-menu-item>
 
     <sw-context-menu-item


### PR DESCRIPTION
### 1. Why is this change necessary?

The extension card context menu prints the raw snippet key `sw-extension-store.component.sw-extension-card-base.contextMenu.config`, because that key was removed and consolidated into `global.default` by shopware/shopware#17651.

### 2. What does this change do, exactly?

Points the context menu at a plugin-owned `swag-paypal.extension-card-base.config` snippet, since the consolidation target `global.default.configure` only exists since 6.7.12 while the plugin supports 6.7.0.

### 3. Describe each step to reproduce the issue or behaviour.

Install the PayPal extension, open Extensions > My extensions and open the context menu of the PayPal card.

### 4. Please link to the relevant issues (if any).

- closes shopware/shopware#19028

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
