### PR TITLE
fix(checkout): strip line breaks from PayPal line item names [6.6.x]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where line item labels containing line breaks made the PayPal order creation fail for local payment methods like iDEAL, P24, EPS or Bancontact
+
 # 9.13.1
 - Fixes an issue, where the same PayPal order could be used for multiple Shopware orders.
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem Positionsbezeichnungen mit Zeilenumbrüchen die Erstellung der PayPal-Bestellung für lokale Zahlungsarten wie iDEAL, P24, EPS oder Bancontact fehlschlagen ließen
+
 # 9.13.1
 - Behebt ein Problem, bei dem dieselbe PayPal-Bestellung für mehrere Shopware-Bestellungen verwendet werden konnte.
 

--- a/src/OrdersApi/Builder/Util/ItemListProvider.php
+++ b/src/OrdersApi/Builder/Util/ItemListProvider.php
@@ -29,6 +29,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Package('checkout')]
 class ItemListProvider
 {
+    private const WHITESPACE_PATTERN = '/[\s\x{0085}\x{2028}\x{2029}]+/u';
+
     /**
      * @internal
      */
@@ -90,6 +92,7 @@ class ItemListProvider
     private function setName(OrderLineItemEntity|LineItem $lineItem, Item $item): void
     {
         $label = $lineItem->getLabel() ?? '';
+        $label = \trim(\preg_replace(self::WHITESPACE_PATTERN, ' ', $label) ?? $label);
 
         try {
             $item->setName($label);

--- a/tests/OrdersApi/Builder/Util/ItemListProviderTest.php
+++ b/tests/OrdersApi/Builder/Util/ItemListProviderTest.php
@@ -167,6 +167,41 @@ class ItemListProviderTest extends TestCase
         static::assertCount(Item::MAX_LENGTH_NAME, \mb_str_split($name));
     }
 
+    #[DataProvider('dataProviderLineBreakLabels')]
+    public function testLineItemLabelWhitespaceIsCollapsed(string $label, string $expectedItemName): void
+    {
+        $order = $this->createOrder($label, 12.34);
+
+        $itemList = $this->createItemListProvider()->getItemList($this->createCurrency(), $order);
+
+        static::assertSame($expectedItemName, $itemList->first()?->getName());
+    }
+
+    #[DataProvider('dataProviderLineBreakLabels')]
+    public function testLineItemLabelWhitespaceIsCollapsedFromCart(string $label, string $expectedItemName): void
+    {
+        $cart = new Cart(Uuid::randomHex());
+        $cart->setLineItems(new LineItemCollection([$this->createCartLineItem($label, 12.34)]));
+        $cart->getPrice()->assign(['taxStatus' => CartPrice::TAX_STATE_GROSS]);
+
+        $itemList = $this->createItemListProvider()->getItemListFromCart($this->createCurrency(), $cart);
+
+        static::assertSame($expectedItemName, $itemList->first()?->getName());
+    }
+
+    public function testLineItemLabelIsTruncatedAfterWhitespaceIsCollapsed(): void
+    {
+        $productName = \str_repeat("a\n", Item::MAX_LENGTH_NAME + 10);
+        $order = $this->createOrder($productName, 12.34);
+
+        $itemList = $this->createItemListProvider()->getItemList($this->createCurrency(), $order);
+
+        $name = $itemList->first()?->getName();
+        static::assertNotNull($name);
+        static::assertCount(Item::MAX_LENGTH_NAME, \mb_str_split($name));
+        static::assertDoesNotMatchRegularExpression('/\s\s|[\r\n]/', $name);
+    }
+
     public function testLineItemProductNumberTooLongIsTruncated(): void
     {
         $productNumber = 'SW-100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
@@ -175,6 +210,28 @@ class ItemListProviderTest extends TestCase
         $itemList = $this->createItemListProvider()->getItemList($this->createCurrency(), $order);
         $expectedItemSku = 'SW-1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
         static::assertSame($expectedItemSku, $itemList->first()?->getSku());
+    }
+
+    /**
+     * PayPal answers with `422 UNPROCESSABLE_ENTITY` / `INVALID_PARAMETER_SYNTAX` on
+     * `/purchase_units/0/items/0/name` for every one of these line terminators.
+     */
+    public static function dataProviderLineBreakLabels(): iterable
+    {
+        return [
+            'line feed' => ["Keim Twinstar\n5kg", 'Keim Twinstar 5kg'],
+            'carriage return' => ["Keim Twinstar\r5kg", 'Keim Twinstar 5kg'],
+            'carriage return line feed' => ["Keim Twinstar\r\n5kg", 'Keim Twinstar 5kg'],
+            'next line' => ["Keim Twinstar\u{0085}5kg", 'Keim Twinstar 5kg'],
+            'line separator' => ["Keim Twinstar\u{2028}5kg", 'Keim Twinstar 5kg'],
+            'paragraph separator' => ["Keim Twinstar\u{2029}5kg", 'Keim Twinstar 5kg'],
+            'tab' => ["Keim Twinstar\t5kg", 'Keim Twinstar 5kg'],
+            'leading and trailing line breaks' => ["\nKeim Twinstar 5kg\n", 'Keim Twinstar 5kg'],
+            'consecutive line breaks' => ["Keim Twinstar\n\n\n5kg", 'Keim Twinstar 5kg'],
+            'line break next to space' => ["Keim Twinstar: \n5kg", 'Keim Twinstar: 5kg'],
+            'label without whitespace to collapse' => ['Keim Twinstar 5kg', 'Keim Twinstar 5kg'],
+            'multibyte characters are kept' => ['Keim Grün Weiß 5kg', 'Keim Grün Weiß 5kg'],
+        ];
     }
 
     public static function dataProviderTaxConstellation(): iterable


### PR DESCRIPTION
### 1. Why is this change necessary?

A line item label containing a line break makes the PayPal order creation fail with `422 UNPROCESSABLE_ENTITY`, so the customer cannot complete the checkout.

Verified against the PayPal sandbox. Same payload, only the item name differs:

```
> POST /v2/checkout/orders
< HTTP/2 422
{"name":"UNPROCESSABLE_ENTITY","details":[{
   "field":"/purchase_units/0/items/0/name",
   "location":"body",
   "issue":"INVALID_PARAMETER_SYNTAX",
   "description":"The value of a field does not conform to the expected format."}]}
```

The important detail: this only happens when a **local payment method** is used as payment source. Orders with no payment source, `paypal` or `card` accept the very same label and even store the line break verbatim, which is why it went unnoticed.

| payment_source | label with `\n` |
|---|---|
| none / `paypal` / `card` (ACDC) | 201 / 200 / 201 — accepted |
| `ideal`, `p24`, `eps`, `bancontact`, `blik`, `mybank` | **422 INVALID_PARAMETER_SYNTAX** |

Rejected characters are exactly the Unicode line terminators — `\n`, `\r`, `\r\n`, NEL (U+0085), LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) — at any position in the label. Tab, vertical tab, form feed, umlauts and emoji are accepted. Only `items[].name` is validated this way; `description`, `sku` and `shipping.name.full_name` accept line breaks, so they are left untouched.

Real-world label that triggered it (a product with a multi-line colour collection description):

```
Keim Twinstar, Wunschfarbton, 5kg\n\nFarbkollektionen: \nKEIM Exclusiv,\nFarbkollektion KEIM Exclusiv: Keim Exclusiv 9475
```

### 2. What does this change do, exactly?

`ItemListProvider::setName()` collapses runs of whitespace in the line item label into single spaces and trims the result, before the label is length-checked and handed to the API.

Collapsing whitespace rather than only replacing line terminators avoids the double spaces a plain replacement would leave behind — the label above ends in `Farbkollektionen: \n`, which would otherwise become `Farbkollektionen:  KEIM`. The sanitized label is confirmed to be accepted by PayPal (`200`) for the same iDEAL order that returned `422` before.

Because sanitizing happens before the length check, a label that only exceeded `Item::MAX_LENGTH_NAME` due to line breaks now fits instead of being truncated.

`sku` is deliberately left as is — PayPal accepts line breaks there.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable a local payment method, e.g. iDEAL (`SwagPayPal.settings` with sandbox credentials).
2. Give a product a name containing a line break, e.g. `Test product\nsecond line`.
3. Put it in the cart and start the checkout with iDEAL.
4. Before this change the PayPal order creation fails with `422 INVALID_PARAMETER_SYNTAX` on `/purchase_units/0/items/0/name`; after it the order is created and the item is named `Test product second line`.

### 4. Please link to the relevant issues (if any).

Backport of shopware/SwagPayPal#781 to 6.6.x (9.13.1).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
