### PR TITLE
fix(devops): sort PayPal SDK struct scan to make openapi schema reproducible

### DIFF
--- a/src/DevOps/Command/GenerateOpenApi.php
+++ b/src/DevOps/Command/GenerateOpenApi.php
@@ -142,6 +142,8 @@ class GenerateOpenApi extends Command
             ->files()
             ->name('*.php')
             ->in(self::ROOT_DIR . '/../../../vendor/shopware/paypal-sdk/src/Struct')
-            ->exclude('AgenticCommerce');
+            ->exclude('AgenticCommerce')
+            // Scan order determines the order of `components.schemas`; unsorted it differs per machine
+            ->sortByName();
     }
 }

--- a/src/Resources/Schema/AdminApi/openapi.json
+++ b/src/Resources/Schema/AdminApi/openapi.json
@@ -5784,8 +5784,7 @@
                 ],
                 "properties": {
                     "liability_shift": {
-                        "type": "string",
-                        "nullable": true
+                        "type": "string"
                     },
                     "three_d_secure": {
                         "oneOf": [

--- a/src/Resources/Schema/AdminApi/openapi.json
+++ b/src/Resources/Schema/AdminApi/openapi.json
@@ -1580,56 +1580,6 @@
                 },
                 "type": "object"
             },
-            "paypal_v3_payment_token": {
-                "required": [
-                    "id",
-                    "status",
-                    "customer",
-                    "payment_source",
-                    "links",
-                    "metadata"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "customer": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
-                    },
-                    "payment_source": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    },
-                    "metadata": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v3_payment_token_metadata"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v3_payment_token_metadata": {
-                "required": [
-                    "order_id"
-                ],
-                "properties": {
-                    "order_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
             "paypal_error_detail": {
                 "required": [
                     "field",
@@ -1757,307 +1707,193 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_merchant_integrations": {
-                "required": [
-                    "merchant_id",
-                    "tracking_id",
-                    "products",
-                    "capabilities",
-                    "oauth_integrations",
-                    "granted_permissions",
-                    "payments_receivable",
-                    "legal_name",
-                    "primary_email",
-                    "primary_email_confirmed"
-                ],
-                "properties": {
-                    "merchant_id": {
-                        "type": "string"
-                    },
-                    "tracking_id": {
-                        "type": "string"
-                    },
-                    "products": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_product"
-                        }
-                    },
-                    "capabilities": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_capability"
-                        },
-                        "nullable": true
-                    },
-                    "oauth_integrations": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration"
-                        }
-                    },
-                    "granted_permissions": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "payments_receivable": {
-                        "type": "boolean"
-                    },
-                    "legal_name": {
-                        "type": "string"
-                    },
-                    "primary_email": {
-                        "type": "string"
-                    },
-                    "primary_email_confirmed": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_refund": {
-                "required": [
-                    "amount",
-                    "invoice_number",
-                    "description",
-                    "reason",
-                    "id",
-                    "create_time",
-                    "update_time",
-                    "state",
-                    "refund_from_transaction_fee",
-                    "total_refunded_amount",
-                    "refund_from_received_amount",
-                    "sale_id",
-                    "capture_id",
-                    "parent_payment",
-                    "links"
-                ],
-                "properties": {
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "invoice_number": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "reason": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "refund_from_transaction_fee": {
+            "paypal_v1_capture_transaction_fee": {
+                "allOf": [
+                    {
                         "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "total_refunded_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "refund_from_received_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "sale_id": {
-                        "type": "string"
-                    },
-                    "capture_id": {
-                        "type": "string"
-                    },
-                    "parent_payment": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
                     }
-                },
-                "type": "object"
+                ]
             },
-            "paypal_v1_webhook_list": {
+            "paypal_v1_client_token": {
                 "required": [
-                    "webhooks"
+                    "client_token",
+                    "expires_in",
+                    "expire_date_time"
                 ],
                 "properties": {
-                    "webhooks": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_webhook"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_shipping_tracker": {
-                "required": [
-                    "transaction_id",
-                    "tracking_number",
-                    "status",
-                    "carrier",
-                    "notify_buyer",
-                    "shipment_date"
-                ],
-                "properties": {
-                    "transaction_id": {
+                    "client_token": {
                         "type": "string"
                     },
-                    "tracking_number": {
-                        "type": "string"
+                    "expires_in": {
+                        "description": "The lifetime of the access token, in seconds.",
+                        "type": "integer"
                     },
-                    "status": {
-                        "type": "string"
-                    },
-                    "carrier": {
-                        "type": "string"
-                    },
-                    "notify_buyer": {
-                        "type": "boolean"
-                    },
-                    "shipment_date": {
+                    "expire_date_time": {
+                        "description": "Calculated expiration date",
                         "type": "string",
                         "format": "date-time"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_merchant_tracking": {
+            "paypal_v1_common_address": {
                 "required": [
-                    "merchant_id",
-                    "tracking_id",
-                    "links"
+                    "line_1",
+                    "line_2",
+                    "city",
+                    "country_code",
+                    "postal_code",
+                    "state",
+                    "phone"
                 ],
                 "properties": {
-                    "merchant_id": {
+                    "line_1": {
                         "type": "string"
                     },
-                    "tracking_id": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_billing_cycle": {
-                "required": [
-                    "frequency",
-                    "tenure_type",
-                    "sequence",
-                    "pricing_scheme",
-                    "total_cycles"
-                ],
-                "properties": {
-                    "frequency": {
-                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_frequency"
-                    },
-                    "tenure_type": {
-                        "type": "string"
-                    },
-                    "sequence": {
-                        "type": "integer"
-                    },
-                    "pricing_scheme": {
-                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_pricing_scheme"
-                    },
-                    "total_cycles": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_billing_cycle_frequency": {
-                "required": [
-                    "interval_unit",
-                    "interval_count"
-                ],
-                "properties": {
-                    "interval_unit": {
-                        "type": "string"
-                    },
-                    "interval_count": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_billing_cycle_pricing_scheme": {
-                "required": [
-                    "fixed_price"
-                ],
-                "properties": {
-                    "fixed_price": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_payment_preferences": {
-                "required": [
-                    "auto_bill_outstanding",
-                    "payment_failure_threshold"
-                ],
-                "properties": {
-                    "auto_bill_outstanding": {
-                        "type": "boolean"
-                    },
-                    "payment_failure_threshold": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_taxes": {
-                "required": [
-                    "percentage",
-                    "inclusive"
-                ],
-                "properties": {
-                    "percentage": {
-                        "type": "string"
-                    },
-                    "inclusive": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_webhook": {
-                "required": [
-                    "id",
-                    "url",
-                    "event_types",
-                    "links"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "url": {
+                    "line_2": {
                         "type": "string",
-                        "maxLength": 2048
+                        "nullable": true
                     },
-                    "event_types": {
+                    "city": {
+                        "type": "string"
+                    },
+                    "country_code": {
+                        "type": "string"
+                    },
+                    "postal_code": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "phone": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_amount": {
+                "required": [
+                    "total",
+                    "currency",
+                    "details"
+                ],
+                "properties": {
+                    "total": {
+                        "type": "string"
+                    },
+                    "currency": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "$ref": "#/components/schemas/paypal_v1_common_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_details": {
+                "required": [
+                    "subtotal",
+                    "shipping",
+                    "tax",
+                    "handling_fee",
+                    "shipping_discount",
+                    "discount",
+                    "insurance"
+                ],
+                "properties": {
+                    "subtotal": {
+                        "type": "string"
+                    },
+                    "shipping": {
+                        "type": "string"
+                    },
+                    "tax": {
+                        "type": "string"
+                    },
+                    "handling_fee": {
+                        "type": "string"
+                    },
+                    "shipping_discount": {
+                        "type": "string"
+                    },
+                    "discount": {
+                        "type": "string"
+                    },
+                    "insurance": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_link": {
+                "required": [
+                    "href",
+                    "rel",
+                    "method",
+                    "enc_type"
+                ],
+                "properties": {
+                    "href": {
+                        "type": "string"
+                    },
+                    "rel": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "type": "string"
+                    },
+                    "enc_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_money": {
+                "required": [
+                    "value",
+                    "currency_code"
+                ],
+                "properties": {
+                    "value": {
+                        "type": "string"
+                    },
+                    "currency_code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_value": {
+                "required": [
+                    "currency",
+                    "value"
+                ],
+                "properties": {
+                    "currency": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes": {
+                "required": [
+                    "items",
+                    "links"
+                ],
+                "properties": {
+                    "items": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_webhook_event_type"
-                        }
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item"
+                        },
+                        "nullable": true
                     },
                     "links": {
                         "type": "array",
@@ -2068,169 +1904,7 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_refund_details": {
-                "required": [
-                    "allowed_refund_amount"
-                ],
-                "properties": {
-                    "allowed_refund_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_offer_history": {
-                "required": [
-                    "offer_time",
-                    "actor",
-                    "event_type",
-                    "offer_type"
-                ],
-                "properties": {
-                    "offer_time": {
-                        "type": "string"
-                    },
-                    "actor": {
-                        "type": "string"
-                    },
-                    "event_type": {
-                        "type": "string"
-                    },
-                    "offer_type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions": {
-                "required": [
-                    "merchant_contacted",
-                    "merchant_contacted_outcome",
-                    "merchant_contacted_time",
-                    "merchant_contacted_mode",
-                    "buyer_contacted_time",
-                    "buyer_contacted_channel",
-                    "billing_dispute_properties",
-                    "merchandize_dispute_properties"
-                ],
-                "properties": {
-                    "merchant_contacted": {
-                        "type": "boolean"
-                    },
-                    "merchant_contacted_outcome": {
-                        "type": "string"
-                    },
-                    "merchant_contacted_time": {
-                        "type": "string"
-                    },
-                    "merchant_contacted_mode": {
-                        "type": "string"
-                    },
-                    "buyer_contacted_time": {
-                        "type": "string"
-                    },
-                    "buyer_contacted_channel": {
-                        "type": "string"
-                    },
-                    "billing_dispute_properties": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties"
-                    },
-                    "merchandize_dispute_properties": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_merchandize_dispute_properties"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_communication_details": {
-                "required": [
-                    "email",
-                    "note",
-                    "time_posted"
-                ],
-                "properties": {
-                    "email": {
-                        "type": "string"
-                    },
-                    "note": {
-                        "type": "string"
-                    },
-                    "time_posted": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_dispute_outcome": {
-                "required": [
-                    "outcome_code",
-                    "amount_refunded"
-                ],
-                "properties": {
-                    "outcome_code": {
-                        "type": "string"
-                    },
-                    "amount_refunded": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_evidence_info_tracking_info": {
-                "required": [
-                    "carrier_name",
-                    "carrier_name_other",
-                    "tracking_url",
-                    "tracking_number"
-                ],
-                "properties": {
-                    "carrier_name": {
-                        "type": "string"
-                    },
-                    "carrier_name_other": {
-                        "type": "string"
-                    },
-                    "tracking_url": {
-                        "type": "string"
-                    },
-                    "tracking_number": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_evidence_info_refund_id": {
-                "required": [
-                    "refund_id"
-                ],
-                "properties": {
-                    "refund_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_evidence_info": {
-                "required": [
-                    "tracking_info",
-                    "refund_ids"
-                ],
-                "properties": {
-                    "tracking_info": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_tracking_info"
-                        }
-                    },
-                    "refund_ids": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_refund_id"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_document": {
+            "paypal_v1_disputes_common_buyer": {
                 "required": [
                     "name"
                 ],
@@ -2241,391 +1915,208 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_evidence": {
+            "paypal_v1_disputes_common_item": {
                 "required": [
-                    "evidence_type",
-                    "evidence_info",
-                    "documents",
-                    "notes",
-                    "item_id"
+                    "item_id",
+                    "item_description",
+                    "item_quantity",
+                    "partner_transaction_id",
+                    "reason",
+                    "dispute_amount",
+                    "notes"
                 ],
                 "properties": {
-                    "evidence_type": {
-                        "type": "string"
-                    },
-                    "evidence_info": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info"
-                    },
-                    "documents": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_document"
-                        }
-                    },
-                    "notes": {
-                        "type": "string"
-                    },
                     "item_id": {
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_disputed_transaction": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
                     },
-                    {
-                        "required": [
-                            "seller_protection_eligible"
-                        ],
-                        "properties": {
-                            "seller_protection_eligible": {
-                                "type": "boolean"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v1_disputes_item_adjudication": {
-                "required": [
-                    "type",
-                    "adjudication_time",
-                    "reason",
-                    "dispute_life_cycle_stage"
-                ],
-                "properties": {
-                    "type": {
+                    "item_description": {
                         "type": "string"
                     },
-                    "adjudication_time": {
+                    "item_quantity": {
+                        "type": "string"
+                    },
+                    "partner_transaction_id": {
                         "type": "string"
                     },
                     "reason": {
                         "type": "string"
                     },
-                    "dispute_life_cycle_stage": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_message": {
-                "required": [
-                    "posted_by",
-                    "time_posted",
-                    "content"
-                ],
-                "properties": {
-                    "posted_by": {
-                        "type": "string"
-                    },
-                    "time_posted": {
-                        "type": "string"
-                    },
-                    "content": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_dispute_amount": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                ]
-            },
-            "paypal_v1_disputes_item_extensions_merchandize_dispute_properties": {
-                "required": [
-                    "issue_type",
-                    "product_details",
-                    "service_details"
-                ],
-                "properties": {
-                    "issue_type": {
-                        "type": "string"
-                    },
-                    "product_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
-                    },
-                    "service_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount": {
-                "required": [
-                    "correct_transaction_amount",
-                    "correct_transaction_time"
-                ],
-                "properties": {
-                    "correct_transaction_amount": {
+                    "dispute_amount": {
                         "$ref": "#/components/schemas/paypal_v1_common_money"
                     },
-                    "correct_transaction_time": {
+                    "notes": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means": {
+            "paypal_v1_disputes_common_product_details": {
                 "required": [
-                    "charge_different_from_original",
-                    "received_duplicate",
-                    "payment_method",
-                    "payment_instrument_suffix"
+                    "product_received",
+                    "product_received_time",
+                    "sub_reasons",
+                    "purchase_url",
+                    "return_details"
                 ],
                 "properties": {
-                    "charge_different_from_original": {
+                    "product_received": {
+                        "type": "string"
+                    },
+                    "product_received_time": {
+                        "type": "string"
+                    },
+                    "sub_reasons": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
+                        }
+                    },
+                    "purchase_url": {
+                        "type": "string"
+                    },
+                    "return_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_return_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_return_details": {
+                "required": [
+                    "return_time",
+                    "mode",
+                    "receipt",
+                    "return_confirmation_number",
+                    "returned"
+                ],
+                "properties": {
+                    "return_time": {
+                        "type": "string"
+                    },
+                    "mode": {
+                        "type": "string"
+                    },
+                    "receipt": {
                         "type": "boolean"
                     },
-                    "received_duplicate": {
+                    "return_confirmation_number": {
+                        "type": "string"
+                    },
+                    "returned": {
                         "type": "boolean"
-                    },
-                    "payment_method": {
-                        "type": "string"
-                    },
-                    "payment_instrument_suffix": {
-                        "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing": {
+            "paypal_v1_disputes_common_seller": {
                 "required": [
-                    "expected_refund",
-                    "cancellation_details"
+                    "email",
+                    "merchant_id",
+                    "name"
                 ],
                 "properties": {
-                    "expected_refund": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "cancellation_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed": {
-                "required": [
-                    "issue_type",
-                    "expected_refund",
-                    "cancellation_details",
-                    "product_details",
-                    "service_details",
-                    "agreed_refund_details"
-                ],
-                "properties": {
-                    "issue_type": {
+                    "email": {
                         "type": "string"
                     },
-                    "expected_refund": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "cancellation_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
-                    },
-                    "product_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
-                    },
-                    "service_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
-                    },
-                    "agreed_refund_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details": {
-                "required": [
-                    "merchant_agreed_refund",
-                    "merchant_agreed_refund_time"
-                ],
-                "properties": {
-                    "merchant_agreed_refund": {
-                        "type": "boolean"
-                    },
-                    "merchant_agreed_refund_time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details": {
-                "required": [
-                    "cancellation_date",
-                    "cancellation_number",
-                    "cancelled",
-                    "cancellation_mode"
-                ],
-                "properties": {
-                    "cancellation_date": {
-                        "type": "string"
-                    },
-                    "cancellation_number": {
-                        "type": "string"
-                    },
-                    "cancelled": {
-                        "type": "boolean"
-                    },
-                    "cancellation_mode": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction": {
-                "required": [
-                    "received_duplicate",
-                    "original_transaction"
-                ],
-                "properties": {
-                    "received_duplicate": {
-                        "type": "boolean"
-                    },
-                    "original_transaction": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties": {
-                "required": [
-                    "duplicate_transaction",
-                    "incorrect_transaction_amount",
-                    "payment_by_other_means",
-                    "credit_not_processed",
-                    "canceled_recurring_billing"
-                ],
-                "properties": {
-                    "duplicate_transaction": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction"
-                    },
-                    "incorrect_transaction_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount"
-                    },
-                    "payment_by_other_means": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means"
-                    },
-                    "credit_not_processed": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed"
-                    },
-                    "canceled_recurring_billing": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_partner_action": {
-                "required": [
-                    "id",
-                    "name",
-                    "create_time",
-                    "update_time",
-                    "due_time",
-                    "status",
-                    "amount"
-                ],
-                "properties": {
-                    "id": {
+                    "merchant_id": {
                         "type": "string"
                     },
                     "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_service_details": {
+                "required": [
+                    "description",
+                    "service_started",
+                    "note",
+                    "sub_reasons",
+                    "purchase_url"
+                ],
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "service_started": {
+                        "type": "string"
+                    },
+                    "note": {
+                        "type": "string"
+                    },
+                    "sub_reasons": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
+                        }
+                    },
+                    "purchase_url": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_sub_reason": {
+                "required": [
+                    "sub_reason"
+                ],
+                "properties": {
+                    "sub_reason": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_transaction": {
+                "required": [
+                    "buyer_transaction_id",
+                    "seller_transaction_id",
+                    "reference_id",
+                    "create_time",
+                    "transaction_status",
+                    "gross_amount",
+                    "invoice_number",
+                    "custom",
+                    "buyer",
+                    "seller",
+                    "items"
+                ],
+                "properties": {
+                    "buyer_transaction_id": {
+                        "type": "string"
+                    },
+                    "seller_transaction_id": {
+                        "type": "string"
+                    },
+                    "reference_id": {
                         "type": "string"
                     },
                     "create_time": {
                         "type": "string"
                     },
-                    "update_time": {
+                    "transaction_status": {
                         "type": "string"
                     },
-                    "due_time": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_offer": {
-                "required": [
-                    "buyer_requested_amount",
-                    "seller_offered_amount",
-                    "offer_type",
-                    "history"
-                ],
-                "properties": {
-                    "buyer_requested_amount": {
+                    "gross_amount": {
                         "$ref": "#/components/schemas/paypal_v1_common_money"
                     },
-                    "seller_offered_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "offer_type": {
+                    "invoice_number": {
                         "type": "string"
                     },
-                    "history": {
+                    "custom": {
+                        "type": "string"
+                    },
+                    "buyer": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_buyer"
+                    },
+                    "seller": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_seller"
+                    },
+                    "items": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_offer_history"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_supporting_info": {
-                "required": [
-                    "notes",
-                    "source",
-                    "provided_time"
-                ],
-                "properties": {
-                    "notes": {
-                        "type": "string"
-                    },
-                    "source": {
-                        "type": "string"
-                    },
-                    "provided_time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_money_movement": {
-                "required": [
-                    "affected_party",
-                    "amount",
-                    "initiated_time",
-                    "type",
-                    "reason"
-                ],
-                "properties": {
-                    "affected_party": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "initiated_time": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "reason": {
-                        "type": "string"
+                            "$ref": "#/components/schemas/paypal_v1_disputes_common_item"
+                        }
                     }
                 },
                 "type": "object"
@@ -2799,213 +2290,120 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_item": {
+            "paypal_v1_disputes_item_adjudication": {
                 "required": [
-                    "item_id",
-                    "item_description",
-                    "item_quantity",
-                    "partner_transaction_id",
+                    "type",
+                    "adjudication_time",
                     "reason",
-                    "dispute_amount",
-                    "notes"
+                    "dispute_life_cycle_stage"
                 ],
                 "properties": {
-                    "item_id": {
+                    "type": {
                         "type": "string"
                     },
-                    "item_description": {
-                        "type": "string"
-                    },
-                    "item_quantity": {
-                        "type": "string"
-                    },
-                    "partner_transaction_id": {
+                    "adjudication_time": {
                         "type": "string"
                     },
                     "reason": {
                         "type": "string"
                     },
-                    "dispute_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "notes": {
+                    "dispute_life_cycle_stage": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_transaction": {
-                "required": [
-                    "buyer_transaction_id",
-                    "seller_transaction_id",
-                    "reference_id",
-                    "create_time",
-                    "transaction_status",
-                    "gross_amount",
-                    "invoice_number",
-                    "custom",
-                    "buyer",
-                    "seller",
-                    "items"
-                ],
-                "properties": {
-                    "buyer_transaction_id": {
-                        "type": "string"
-                    },
-                    "seller_transaction_id": {
-                        "type": "string"
-                    },
-                    "reference_id": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "transaction_status": {
-                        "type": "string"
-                    },
-                    "gross_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "invoice_number": {
-                        "type": "string"
-                    },
-                    "custom": {
-                        "type": "string"
-                    },
-                    "buyer": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_buyer"
-                    },
-                    "seller": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_seller"
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_common_item"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_product_details": {
-                "required": [
-                    "product_received",
-                    "product_received_time",
-                    "sub_reasons",
-                    "purchase_url",
-                    "return_details"
-                ],
-                "properties": {
-                    "product_received": {
-                        "type": "string"
-                    },
-                    "product_received_time": {
-                        "type": "string"
-                    },
-                    "sub_reasons": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
-                        }
-                    },
-                    "purchase_url": {
-                        "type": "string"
-                    },
-                    "return_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_return_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_seller": {
+            "paypal_v1_disputes_item_communication_details": {
                 "required": [
                     "email",
-                    "merchant_id",
-                    "name"
+                    "note",
+                    "time_posted"
                 ],
                 "properties": {
                     "email": {
                         "type": "string"
                     },
-                    "merchant_id": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_sub_reason": {
-                "required": [
-                    "sub_reason"
-                ],
-                "properties": {
-                    "sub_reason": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_service_details": {
-                "required": [
-                    "description",
-                    "service_started",
-                    "note",
-                    "sub_reasons",
-                    "purchase_url"
-                ],
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "service_started": {
-                        "type": "string"
-                    },
                     "note": {
                         "type": "string"
                     },
-                    "sub_reasons": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
-                        }
-                    },
-                    "purchase_url": {
+                    "time_posted": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_return_details": {
+            "paypal_v1_disputes_item_dispute_amount": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    }
+                ]
+            },
+            "paypal_v1_disputes_item_dispute_outcome": {
                 "required": [
-                    "return_time",
-                    "mode",
-                    "receipt",
-                    "return_confirmation_number",
-                    "returned"
+                    "outcome_code",
+                    "amount_refunded"
                 ],
                 "properties": {
-                    "return_time": {
+                    "outcome_code": {
                         "type": "string"
                     },
-                    "mode": {
-                        "type": "string"
-                    },
-                    "receipt": {
-                        "type": "boolean"
-                    },
-                    "return_confirmation_number": {
-                        "type": "string"
-                    },
-                    "returned": {
-                        "type": "boolean"
+                    "amount_refunded": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_buyer": {
+            "paypal_v1_disputes_item_disputed_transaction": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
+                    },
+                    {
+                        "required": [
+                            "seller_protection_eligible"
+                        ],
+                        "properties": {
+                            "seller_protection_eligible": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v1_disputes_item_evidence": {
+                "required": [
+                    "evidence_type",
+                    "evidence_info",
+                    "documents",
+                    "notes",
+                    "item_id"
+                ],
+                "properties": {
+                    "evidence_type": {
+                        "type": "string"
+                    },
+                    "evidence_info": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info"
+                    },
+                    "documents": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_document"
+                        }
+                    },
+                    "notes": {
+                        "type": "string"
+                    },
+                    "item_id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_evidence_document": {
                 "required": [
                     "name"
                 ],
@@ -3016,242 +2414,440 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_webhook_event_type": {
+            "paypal_v1_disputes_item_evidence_evidence_info": {
                 "required": [
-                    "name",
-                    "description",
-                    "status",
-                    "resource_version"
+                    "tracking_info",
+                    "refund_ids"
                 ],
                 "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "resource_version": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_webhook_event": {
-                "required": [
-                    "id",
-                    "resource_type",
-                    "event_type",
-                    "summary",
-                    "resource",
-                    "create_time",
-                    "links",
-                    "event_version",
-                    "resource_version"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "resource_type": {
-                        "type": "string"
-                    },
-                    "event_type": {
-                        "type": "string"
-                    },
-                    "summary": {
-                        "type": "string"
-                    },
-                    "resource": {
-                        "nullable": true,
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v3_payment_token"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_webhook_resource"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription"
-                            }
-                        ]
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "links": {
+                    "tracking_info": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_tracking_info"
                         }
                     },
-                    "event_version": {
-                        "type": "string"
-                    },
-                    "resource_version": {
+                    "refund_ids": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_refund_id"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_evidence_evidence_info_refund_id": {
+                "required": [
+                    "refund_id"
+                ],
+                "properties": {
+                    "refund_id": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_webhook_resource": {
+            "paypal_v1_disputes_item_evidence_evidence_info_tracking_info": {
                 "required": [
-                    "id",
-                    "parent_payment",
-                    "billing_agreement_id",
-                    "sale_id",
-                    "refund_reason_code",
-                    "update_time",
-                    "amount",
-                    "payment_mode",
-                    "create_time",
-                    "clearing_time",
-                    "protection_eligibility_type",
-                    "protection_eligibility",
-                    "transaction_fee",
-                    "invoice_number",
-                    "links",
-                    "state",
-                    "merchant_id"
+                    "carrier_name",
+                    "carrier_name_other",
+                    "tracking_url",
+                    "tracking_number"
                 ],
                 "properties": {
-                    "id": {
+                    "carrier_name": {
                         "type": "string"
                     },
-                    "parent_payment": {
-                        "type": "string",
-                        "nullable": true
+                    "carrier_name_other": {
+                        "type": "string"
                     },
-                    "billing_agreement_id": {
-                        "type": "string",
-                        "nullable": true
+                    "tracking_url": {
+                        "type": "string"
                     },
-                    "sale_id": {
-                        "type": "string",
-                        "nullable": true
+                    "tracking_number": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions": {
+                "required": [
+                    "merchant_contacted",
+                    "merchant_contacted_outcome",
+                    "merchant_contacted_time",
+                    "merchant_contacted_mode",
+                    "buyer_contacted_time",
+                    "buyer_contacted_channel",
+                    "billing_dispute_properties",
+                    "merchandize_dispute_properties"
+                ],
+                "properties": {
+                    "merchant_contacted": {
+                        "type": "boolean"
                     },
-                    "refund_reason_code": {
-                        "type": "string",
-                        "nullable": true
+                    "merchant_contacted_outcome": {
+                        "type": "string"
                     },
-                    "update_time": {
+                    "merchant_contacted_time": {
+                        "type": "string"
+                    },
+                    "merchant_contacted_mode": {
+                        "type": "string"
+                    },
+                    "buyer_contacted_time": {
+                        "type": "string"
+                    },
+                    "buyer_contacted_channel": {
+                        "type": "string"
+                    },
+                    "billing_dispute_properties": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties"
+                    },
+                    "merchandize_dispute_properties": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_merchandize_dispute_properties"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties": {
+                "required": [
+                    "duplicate_transaction",
+                    "incorrect_transaction_amount",
+                    "payment_by_other_means",
+                    "credit_not_processed",
+                    "canceled_recurring_billing"
+                ],
+                "properties": {
+                    "duplicate_transaction": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction"
+                    },
+                    "incorrect_transaction_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount"
+                    },
+                    "payment_by_other_means": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means"
+                    },
+                    "credit_not_processed": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed"
+                    },
+                    "canceled_recurring_billing": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing": {
+                "required": [
+                    "expected_refund",
+                    "cancellation_details"
+                ],
+                "properties": {
+                    "expected_refund": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "cancellation_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details": {
+                "required": [
+                    "merchant_agreed_refund",
+                    "merchant_agreed_refund_time"
+                ],
+                "properties": {
+                    "merchant_agreed_refund": {
+                        "type": "boolean"
+                    },
+                    "merchant_agreed_refund_time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details": {
+                "required": [
+                    "cancellation_date",
+                    "cancellation_number",
+                    "cancelled",
+                    "cancellation_mode"
+                ],
+                "properties": {
+                    "cancellation_date": {
+                        "type": "string"
+                    },
+                    "cancellation_number": {
+                        "type": "string"
+                    },
+                    "cancelled": {
+                        "type": "boolean"
+                    },
+                    "cancellation_mode": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed": {
+                "required": [
+                    "issue_type",
+                    "expected_refund",
+                    "cancellation_details",
+                    "product_details",
+                    "service_details",
+                    "agreed_refund_details"
+                ],
+                "properties": {
+                    "issue_type": {
+                        "type": "string"
+                    },
+                    "expected_refund": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "cancellation_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
+                    },
+                    "product_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
+                    },
+                    "service_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
+                    },
+                    "agreed_refund_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction": {
+                "required": [
+                    "received_duplicate",
+                    "original_transaction"
+                ],
+                "properties": {
+                    "received_duplicate": {
+                        "type": "boolean"
+                    },
+                    "original_transaction": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount": {
+                "required": [
+                    "correct_transaction_amount",
+                    "correct_transaction_time"
+                ],
+                "properties": {
+                    "correct_transaction_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "correct_transaction_time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means": {
+                "required": [
+                    "charge_different_from_original",
+                    "received_duplicate",
+                    "payment_method",
+                    "payment_instrument_suffix"
+                ],
+                "properties": {
+                    "charge_different_from_original": {
+                        "type": "boolean"
+                    },
+                    "received_duplicate": {
+                        "type": "boolean"
+                    },
+                    "payment_method": {
+                        "type": "string"
+                    },
+                    "payment_instrument_suffix": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_merchandize_dispute_properties": {
+                "required": [
+                    "issue_type",
+                    "product_details",
+                    "service_details"
+                ],
+                "properties": {
+                    "issue_type": {
+                        "type": "string"
+                    },
+                    "product_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
+                    },
+                    "service_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_message": {
+                "required": [
+                    "posted_by",
+                    "time_posted",
+                    "content"
+                ],
+                "properties": {
+                    "posted_by": {
+                        "type": "string"
+                    },
+                    "time_posted": {
+                        "type": "string"
+                    },
+                    "content": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_money_movement": {
+                "required": [
+                    "affected_party",
+                    "amount",
+                    "initiated_time",
+                    "type",
+                    "reason"
+                ],
+                "properties": {
+                    "affected_party": {
                         "type": "string"
                     },
                     "amount": {
                         "$ref": "#/components/schemas/paypal_v1_common_amount"
                     },
-                    "payment_mode": {
+                    "initiated_time": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_offer": {
+                "required": [
+                    "buyer_requested_amount",
+                    "seller_offered_amount",
+                    "offer_type",
+                    "history"
+                ],
+                "properties": {
+                    "buyer_requested_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "seller_offered_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "offer_type": {
+                        "type": "string"
+                    },
+                    "history": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_offer_history"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_offer_history": {
+                "required": [
+                    "offer_time",
+                    "actor",
+                    "event_type",
+                    "offer_type"
+                ],
+                "properties": {
+                    "offer_time": {
+                        "type": "string"
+                    },
+                    "actor": {
+                        "type": "string"
+                    },
+                    "event_type": {
+                        "type": "string"
+                    },
+                    "offer_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_partner_action": {
+                "required": [
+                    "id",
+                    "name",
+                    "create_time",
+                    "update_time",
+                    "due_time",
+                    "status",
+                    "amount"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
                         "type": "string"
                     },
                     "create_time": {
                         "type": "string"
                     },
-                    "clearing_time": {
+                    "update_time": {
                         "type": "string"
                     },
-                    "protection_eligibility_type": {
+                    "due_time": {
                         "type": "string"
                     },
-                    "protection_eligibility": {
+                    "status": {
                         "type": "string"
                     },
-                    "transaction_fee": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "invoice_number": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "merchant_id": {
-                        "type": "string",
-                        "nullable": true
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_token": {
+            "paypal_v1_disputes_item_refund_details": {
                 "required": [
-                    "scope",
-                    "nonce",
-                    "access_token",
-                    "token_type",
-                    "app_id",
-                    "id_token",
-                    "expires_in",
-                    "expire_date_time"
+                    "allowed_refund_amount"
                 ],
                 "properties": {
-                    "scope": {
-                        "description": "Scopes expressed in the form of resource URL endpoints. The value of the scope parameter\nis expressed as a list of space-delimited, case-sensitive strings.",
-                        "type": "string"
-                    },
-                    "nonce": {
-                        "type": "string"
-                    },
-                    "access_token": {
-                        "description": "The access token issued by PayPal. After the access token\nexpires (see $expiresIn), you must request a new access token.",
-                        "type": "string"
-                    },
-                    "token_type": {
-                        "description": "The type of the token issued as described in OAuth2.0 RFC6749,\nSection 7.1. Value is case insensitive.",
-                        "type": "string"
-                    },
-                    "app_id": {
-                        "type": "string"
-                    },
-                    "id_token": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "expires_in": {
-                        "description": "The lifetime of the access token, in seconds.",
-                        "type": "integer"
-                    },
-                    "expire_date_time": {
-                        "description": "Calculated expiration date",
-                        "type": "string",
-                        "format": "date-time"
+                    "allowed_refund_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_client_token": {
+            "paypal_v1_disputes_item_supporting_info": {
                 "required": [
-                    "client_token",
-                    "expires_in",
-                    "expire_date_time"
+                    "notes",
+                    "source",
+                    "provided_time"
                 ],
                 "properties": {
-                    "client_token": {
+                    "notes": {
                         "type": "string"
                     },
-                    "expires_in": {
-                        "description": "The lifetime of the access token, in seconds.",
-                        "type": "integer"
+                    "source": {
+                        "type": "string"
                     },
-                    "expire_date_time": {
-                        "description": "Calculated expiration date",
-                        "type": "string",
-                        "format": "date-time"
+                    "provided_time": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -3294,148 +2890,295 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_common_value": {
+            "paypal_v1_merchant_integrations": {
                 "required": [
-                    "currency",
+                    "merchant_id",
+                    "tracking_id",
+                    "products",
+                    "capabilities",
+                    "oauth_integrations",
+                    "granted_permissions",
+                    "payments_receivable",
+                    "legal_name",
+                    "primary_email",
+                    "primary_email_confirmed"
+                ],
+                "properties": {
+                    "merchant_id": {
+                        "type": "string"
+                    },
+                    "tracking_id": {
+                        "type": "string"
+                    },
+                    "products": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_product"
+                        }
+                    },
+                    "capabilities": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_capability"
+                        },
+                        "nullable": true
+                    },
+                    "oauth_integrations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration"
+                        }
+                    },
+                    "granted_permissions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "payments_receivable": {
+                        "type": "boolean"
+                    },
+                    "legal_name": {
+                        "type": "string"
+                    },
+                    "primary_email": {
+                        "type": "string"
+                    },
+                    "primary_email_confirmed": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_capability": {
+                "required": [
+                    "name",
+                    "status"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_credentials": {
+                "required": [
+                    "client_id",
+                    "client_secret",
+                    "payer_id"
+                ],
+                "properties": {
+                    "client_id": {
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "type": "string"
+                    },
+                    "payer_id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_oauth_integration": {
+                "required": [
+                    "integrationMethod",
+                    "integrationType",
+                    "oauthThirdParty"
+                ],
+                "properties": {
+                    "integration_method": {
+                        "type": "string"
+                    },
+                    "integration_type": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "oauth_third_party": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration_oauth_third_party"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_oauth_integration_oauth_third_party": {
+                "required": [
+                    "merchantClientId",
+                    "partnerClientId",
+                    "scopes"
+                ],
+                "properties": {
+                    "access_token": {
+                        "type": "string"
+                    },
+                    "merchant_client_id": {
+                        "type": "string"
+                    },
+                    "partner_client_id": {
+                        "type": "string"
+                    },
+                    "refresh_token": {
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_product": {
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "vetting_status": {
+                        "type": "string"
+                    },
+                    "capabilities": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_tracking": {
+                "required": [
+                    "merchant_id",
+                    "tracking_id",
+                    "links"
+                ],
+                "properties": {
+                    "merchant_id": {
+                        "type": "string"
+                    },
+                    "tracking_id": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_patch": {
+                "required": [
+                    "op",
+                    "path",
                     "value"
                 ],
                 "properties": {
-                    "currency": {
+                    "op": {
+                        "type": "string",
+                        "enum": [
+                            "add",
+                            "replace"
+                        ]
+                    },
+                    "path": {
                         "type": "string"
                     },
                     "value": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        ]
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_common_link": {
+            "paypal_v1_payment": {
                 "required": [
-                    "href",
-                    "rel",
-                    "method",
-                    "enc_type"
-                ],
-                "properties": {
-                    "href": {
-                        "type": "string"
-                    },
-                    "rel": {
-                        "type": "string"
-                    },
-                    "method": {
-                        "type": "string"
-                    },
-                    "enc_type": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_details": {
-                "required": [
-                    "subtotal",
-                    "shipping",
-                    "tax",
-                    "handling_fee",
-                    "shipping_discount",
-                    "discount",
-                    "insurance"
-                ],
-                "properties": {
-                    "subtotal": {
-                        "type": "string"
-                    },
-                    "shipping": {
-                        "type": "string"
-                    },
-                    "tax": {
-                        "type": "string"
-                    },
-                    "handling_fee": {
-                        "type": "string"
-                    },
-                    "shipping_discount": {
-                        "type": "string"
-                    },
-                    "discount": {
-                        "type": "string"
-                    },
-                    "insurance": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_amount": {
-                "required": [
-                    "total",
-                    "currency",
-                    "details"
-                ],
-                "properties": {
-                    "total": {
-                        "type": "string"
-                    },
-                    "currency": {
-                        "type": "string"
-                    },
-                    "details": {
-                        "$ref": "#/components/schemas/paypal_v1_common_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_address": {
-                "required": [
-                    "line_1",
-                    "line_2",
-                    "city",
-                    "country_code",
-                    "postal_code",
+                    "id",
                     "state",
-                    "phone"
+                    "cart",
+                    "payer",
+                    "transactions",
+                    "create_time",
+                    "update_time",
+                    "links",
+                    "redirect_urls",
+                    "application_context",
+                    "payment_instruction"
                 ],
                 "properties": {
-                    "line_1": {
+                    "id": {
                         "type": "string"
                     },
-                    "line_2": {
+                    "intent": {
                         "type": "string",
-                        "nullable": true
-                    },
-                    "city": {
-                        "type": "string"
-                    },
-                    "country_code": {
-                        "type": "string"
-                    },
-                    "postal_code": {
-                        "type": "string"
+                        "default": "sale",
+                        "enum": [
+                            "sale",
+                            "authorize",
+                            "order"
+                        ]
                     },
                     "state": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "phone": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_money": {
-                "required": [
-                    "value",
-                    "currency_code"
-                ],
-                "properties": {
-                    "value": {
                         "type": "string"
                     },
-                    "currency_code": {
+                    "cart": {
                         "type": "string"
+                    },
+                    "payer": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payer"
+                    },
+                    "transactions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_payment_transaction"
+                        }
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "redirect_urls": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_redirect_urls"
+                    },
+                    "application_context": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_application_context"
+                    },
+                    "payment_instruction": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction"
+                            }
+                        ],
+                        "nullable": true
                     }
                 },
                 "type": "object"
@@ -3467,6 +3210,160 @@
                     "user_action": {
                         "type": "string",
                         "default": "commit"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payer": {
+                "required": [
+                    "payment_method",
+                    "status",
+                    "payer_info",
+                    "external_selected_funding_instrument_type"
+                ],
+                "properties": {
+                    "payment_method": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "payer_info": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payer_payer_info"
+                    },
+                    "external_selected_funding_instrument_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payer_execute_payer_info": {
+                "required": [
+                    "payer_id"
+                ],
+                "properties": {
+                    "payer_id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payer_payer_info": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payer_execute_payer_info"
+                    },
+                    {
+                        "required": [
+                            "email",
+                            "first_name",
+                            "last_name",
+                            "billing_address",
+                            "shipping_address",
+                            "phone",
+                            "country_code"
+                        ],
+                        "properties": {
+                            "email": {
+                                "type": "string"
+                            },
+                            "first_name": {
+                                "type": "string"
+                            },
+                            "last_name": {
+                                "type": "string"
+                            },
+                            "billing_address": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/paypal_v1_common_address"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "shipping_address": {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
+                            },
+                            "phone": {
+                                "type": "string"
+                            },
+                            "country_code": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v1_payment_payment_instruction": {
+                "required": [
+                    "reference_number",
+                    "recipient_banking_instruction",
+                    "amount",
+                    "payment_due_date",
+                    "instruction_type",
+                    "links"
+                ],
+                "properties": {
+                    "reference_number": {
+                        "type": "string"
+                    },
+                    "recipient_banking_instruction": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction_recipient_banking_instruction"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "payment_due_date": {
+                        "type": "string"
+                    },
+                    "instruction_type": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payment_instruction_recipient_banking_instruction": {
+                "required": [
+                    "bank_name",
+                    "account_holder_name",
+                    "international_bank_account_number",
+                    "bank_identifier_code"
+                ],
+                "properties": {
+                    "bank_name": {
+                        "type": "string"
+                    },
+                    "account_holder_name": {
+                        "type": "string"
+                    },
+                    "international_bank_account_number": {
+                        "type": "string"
+                    },
+                    "bank_identifier_code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_redirect_urls": {
+                "required": [
+                    "return_url",
+                    "cancel_url"
+                ],
+                "properties": {
+                    "return_url": {
+                        "type": "string"
+                    },
+                    "cancel_url": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -3519,38 +3416,90 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_payment_payment_instruction": {
+            "paypal_v1_payment_transaction_item_list": {
                 "required": [
-                    "reference_number",
-                    "recipient_banking_instruction",
-                    "amount",
-                    "payment_due_date",
-                    "instruction_type",
-                    "links"
+                    "shipping_address",
+                    "items",
+                    "shipping_options",
+                    "shipping_phone_number"
                 ],
                 "properties": {
-                    "reference_number": {
-                        "type": "string"
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
                     },
-                    "recipient_banking_instruction": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction_recipient_banking_instruction"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "payment_due_date": {
-                        "type": "string"
-                    },
-                    "instruction_type": {
-                        "type": "string"
-                    },
-                    "links": {
+                    "items": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_item"
                         }
+                    },
+                    "shipping_options": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_option"
+                        }
+                    },
+                    "shipping_phone_number": {
+                        "type": "string"
                     }
                 },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_item_list_item": {
+                "required": [
+                    "name",
+                    "currency",
+                    "price",
+                    "quantity",
+                    "sku",
+                    "tax"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 127
+                    },
+                    "currency": {
+                        "type": "string"
+                    },
+                    "price": {
+                        "type": "string"
+                    },
+                    "quantity": {
+                        "type": "integer"
+                    },
+                    "sku": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 127
+                    },
+                    "tax": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_item_list_shipping_address": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_common_address"
+                    },
+                    {
+                        "required": [
+                            "recipient_name"
+                        ],
+                        "properties": {
+                            "recipient_name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v1_payment_transaction_item_list_shipping_option": {
+                "properties": {},
                 "type": "object"
             },
             "paypal_v1_payment_transaction_payee": {
@@ -3563,6 +3512,120 @@
                         "type": "string"
                     },
                     "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_related_resource": {
+                "required": [
+                    "sale",
+                    "authorization",
+                    "order",
+                    "refund",
+                    "capture"
+                ],
+                "properties": {
+                    "sale": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_sale"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "authorization": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_authorization"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "order": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_order"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "refund": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_refund"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "capture": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_capture"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_related_resource_authorization": {
+                "required": [
+                    "id",
+                    "state",
+                    "amount",
+                    "payment_mode",
+                    "create_time",
+                    "update_time",
+                    "protection_eligibility",
+                    "protection_eligibility_type",
+                    "receipt_id",
+                    "parent_payment",
+                    "links",
+                    "reason_code",
+                    "valid_until"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "payment_mode": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "protection_eligibility": {
+                        "type": "string"
+                    },
+                    "protection_eligibility_type": {
+                        "type": "string"
+                    },
+                    "receipt_id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "reason_code": {
+                        "type": "string"
+                    },
+                    "valid_until": {
                         "type": "string"
                     }
                 },
@@ -3629,6 +3692,64 @@
                         "$ref": "#/components/schemas/paypal_v1_common_value"
                     },
                     "invoice_number": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_related_resource_order": {
+                "required": [
+                    "id",
+                    "state",
+                    "amount",
+                    "payment_mode",
+                    "create_time",
+                    "update_time",
+                    "protection_eligibility",
+                    "protection_eligibility_type",
+                    "receipt_id",
+                    "parent_payment",
+                    "links",
+                    "reason_code"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "payment_mode": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "protection_eligibility": {
+                        "type": "string"
+                    },
+                    "protection_eligibility_type": {
+                        "type": "string"
+                    },
+                    "receipt_id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "reason_code": {
                         "type": "string"
                     }
                 },
@@ -3754,662 +3875,6 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_payment_transaction_related_resource_order": {
-                "required": [
-                    "id",
-                    "state",
-                    "amount",
-                    "payment_mode",
-                    "create_time",
-                    "update_time",
-                    "protection_eligibility",
-                    "protection_eligibility_type",
-                    "receipt_id",
-                    "parent_payment",
-                    "links",
-                    "reason_code"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "payment_mode": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "protection_eligibility": {
-                        "type": "string"
-                    },
-                    "protection_eligibility_type": {
-                        "type": "string"
-                    },
-                    "receipt_id": {
-                        "type": "string"
-                    },
-                    "parent_payment": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "reason_code": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_related_resource_authorization": {
-                "required": [
-                    "id",
-                    "state",
-                    "amount",
-                    "payment_mode",
-                    "create_time",
-                    "update_time",
-                    "protection_eligibility",
-                    "protection_eligibility_type",
-                    "receipt_id",
-                    "parent_payment",
-                    "links",
-                    "reason_code",
-                    "valid_until"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "payment_mode": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "protection_eligibility": {
-                        "type": "string"
-                    },
-                    "protection_eligibility_type": {
-                        "type": "string"
-                    },
-                    "receipt_id": {
-                        "type": "string"
-                    },
-                    "parent_payment": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "reason_code": {
-                        "type": "string"
-                    },
-                    "valid_until": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list": {
-                "required": [
-                    "shipping_address",
-                    "items",
-                    "shipping_options",
-                    "shipping_phone_number"
-                ],
-                "properties": {
-                    "shipping_address": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_item"
-                        }
-                    },
-                    "shipping_options": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_option"
-                        }
-                    },
-                    "shipping_phone_number": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list_item": {
-                "required": [
-                    "name",
-                    "currency",
-                    "price",
-                    "quantity",
-                    "sku",
-                    "tax"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 127
-                    },
-                    "currency": {
-                        "type": "string"
-                    },
-                    "price": {
-                        "type": "string"
-                    },
-                    "quantity": {
-                        "type": "integer"
-                    },
-                    "sku": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 127
-                    },
-                    "tax": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list_shipping_option": {
-                "properties": {},
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list_shipping_address": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_common_address"
-                    },
-                    {
-                        "required": [
-                            "recipient_name"
-                        ],
-                        "properties": {
-                            "recipient_name": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v1_payment_transaction_related_resource": {
-                "required": [
-                    "sale",
-                    "authorization",
-                    "order",
-                    "refund",
-                    "capture"
-                ],
-                "properties": {
-                    "sale": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_sale"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "authorization": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_authorization"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "order": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_order"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "refund": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_refund"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "capture": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_capture"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payer_execute_payer_info": {
-                "required": [
-                    "payer_id"
-                ],
-                "properties": {
-                    "payer_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payer_payer_info": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payer_execute_payer_info"
-                    },
-                    {
-                        "required": [
-                            "email",
-                            "first_name",
-                            "last_name",
-                            "billing_address",
-                            "shipping_address",
-                            "phone",
-                            "country_code"
-                        ],
-                        "properties": {
-                            "email": {
-                                "type": "string"
-                            },
-                            "first_name": {
-                                "type": "string"
-                            },
-                            "last_name": {
-                                "type": "string"
-                            },
-                            "billing_address": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/paypal_v1_common_address"
-                                    }
-                                ],
-                                "nullable": true
-                            },
-                            "shipping_address": {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
-                            },
-                            "phone": {
-                                "type": "string"
-                            },
-                            "country_code": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v1_payment_redirect_urls": {
-                "required": [
-                    "return_url",
-                    "cancel_url"
-                ],
-                "properties": {
-                    "return_url": {
-                        "type": "string"
-                    },
-                    "cancel_url": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payer": {
-                "required": [
-                    "payment_method",
-                    "status",
-                    "payer_info",
-                    "external_selected_funding_instrument_type"
-                ],
-                "properties": {
-                    "payment_method": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "payer_info": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payer_payer_info"
-                    },
-                    "external_selected_funding_instrument_type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payment_instruction_recipient_banking_instruction": {
-                "required": [
-                    "bank_name",
-                    "account_holder_name",
-                    "international_bank_account_number",
-                    "bank_identifier_code"
-                ],
-                "properties": {
-                    "bank_name": {
-                        "type": "string"
-                    },
-                    "account_holder_name": {
-                        "type": "string"
-                    },
-                    "international_bank_account_number": {
-                        "type": "string"
-                    },
-                    "bank_identifier_code": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_patch": {
-                "required": [
-                    "op",
-                    "path",
-                    "value"
-                ],
-                "properties": {
-                    "op": {
-                        "type": "string",
-                        "enum": [
-                            "add",
-                            "replace"
-                        ]
-                    },
-                    "path": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "mixed"
-                                }
-                            }
-                        ]
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_product": {
-                "required": [
-                    "name",
-                    "description",
-                    "type"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_application_context": {
-                "required": [
-                    "brand_name",
-                    "locale",
-                    "return_url",
-                    "cancel_url"
-                ],
-                "properties": {
-                    "user_action": {
-                        "type": "string",
-                        "default": "SUBSCRIBE_NOW"
-                    },
-                    "brand_name": {
-                        "type": "string"
-                    },
-                    "locale": {
-                        "type": "string"
-                    },
-                    "shipping_preference": {
-                        "type": "string",
-                        "default": "SET_PROVIDED_ADDRESS"
-                    },
-                    "return_url": {
-                        "type": "string"
-                    },
-                    "cancel_url": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_billing_info_cycle_execution": {
-                "required": [
-                    "tenure_type",
-                    "sequence",
-                    "cycles_completed",
-                    "cycles_remaining",
-                    "total_cycles"
-                ],
-                "properties": {
-                    "tenure_type": {
-                        "type": "string"
-                    },
-                    "sequence": {
-                        "type": "integer"
-                    },
-                    "cycles_completed": {
-                        "type": "integer"
-                    },
-                    "cycles_remaining": {
-                        "type": "integer"
-                    },
-                    "total_cycles": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_billing_info_outstanding_balance": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                ]
-            },
-            "paypal_v1_subscription_billing_info_last_payment": {
-                "required": [
-                    "amount",
-                    "time"
-                ],
-                "properties": {
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_billing_info": {
-                "required": [
-                    "outstanding_balance",
-                    "cycle_executions",
-                    "last_payment",
-                    "next_billing_time",
-                    "failed_payments_count"
-                ],
-                "properties": {
-                    "outstanding_balance": {
-                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_outstanding_balance"
-                    },
-                    "cycle_executions": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_cycle_execution"
-                        }
-                    },
-                    "last_payment": {
-                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_last_payment"
-                    },
-                    "next_billing_time": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "failed_payments_count": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_name": {
-                "required": [
-                    "given_name",
-                    "surname"
-                ],
-                "properties": {
-                    "given_name": {
-                        "type": "string"
-                    },
-                    "surname": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_shipping_address_name": {
-                "required": [
-                    "full_name"
-                ],
-                "properties": {
-                    "full_name": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_shipping_address_address": {
-                "required": [
-                    "address_line_1",
-                    "address_line_2",
-                    "admin_area_1",
-                    "admin_area_2",
-                    "postal_code",
-                    "country_code"
-                ],
-                "properties": {
-                    "address_line_1": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "address_line_2": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "admin_area_1": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "admin_area_2": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "postal_code": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "country_code": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_shipping_address": {
-                "required": [
-                    "name",
-                    "address"
-                ],
-                "properties": {
-                    "name": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_name"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "address": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_address"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber": {
-                "required": [
-                    "name",
-                    "email_address",
-                    "payer_id",
-                    "shipping_address"
-                ],
-                "properties": {
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_name"
-                    },
-                    "email_address": {
-                        "type": "string"
-                    },
-                    "payer_id": {
-                        "type": "string"
-                    },
-                    "shipping_address": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
             "paypal_v1_plan": {
                 "required": [
                     "product_id",
@@ -4449,6 +3914,178 @@
                 },
                 "type": "object"
             },
+            "paypal_v1_plan_billing_cycle": {
+                "required": [
+                    "frequency",
+                    "tenure_type",
+                    "sequence",
+                    "pricing_scheme",
+                    "total_cycles"
+                ],
+                "properties": {
+                    "frequency": {
+                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_frequency"
+                    },
+                    "tenure_type": {
+                        "type": "string"
+                    },
+                    "sequence": {
+                        "type": "integer"
+                    },
+                    "pricing_scheme": {
+                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_pricing_scheme"
+                    },
+                    "total_cycles": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_billing_cycle_frequency": {
+                "required": [
+                    "interval_unit",
+                    "interval_count"
+                ],
+                "properties": {
+                    "interval_unit": {
+                        "type": "string"
+                    },
+                    "interval_count": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_billing_cycle_pricing_scheme": {
+                "required": [
+                    "fixed_price"
+                ],
+                "properties": {
+                    "fixed_price": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_payment_preferences": {
+                "required": [
+                    "auto_bill_outstanding",
+                    "payment_failure_threshold"
+                ],
+                "properties": {
+                    "auto_bill_outstanding": {
+                        "type": "boolean"
+                    },
+                    "payment_failure_threshold": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_taxes": {
+                "required": [
+                    "percentage",
+                    "inclusive"
+                ],
+                "properties": {
+                    "percentage": {
+                        "type": "string"
+                    },
+                    "inclusive": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_product": {
+                "required": [
+                    "name",
+                    "description",
+                    "type"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_refund": {
+                "required": [
+                    "amount",
+                    "invoice_number",
+                    "description",
+                    "reason",
+                    "id",
+                    "create_time",
+                    "update_time",
+                    "state",
+                    "refund_from_transaction_fee",
+                    "total_refunded_amount",
+                    "refund_from_received_amount",
+                    "sale_id",
+                    "capture_id",
+                    "parent_payment",
+                    "links"
+                ],
+                "properties": {
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "invoice_number": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "refund_from_transaction_fee": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "total_refunded_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "refund_from_received_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "sale_id": {
+                        "type": "string"
+                    },
+                    "capture_id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v1_shipping": {
                 "required": [
                     "trackers"
@@ -4459,6 +4096,38 @@
                         "items": {
                             "$ref": "#/components/schemas/paypal_v1_shipping_tracker"
                         }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_shipping_tracker": {
+                "required": [
+                    "transaction_id",
+                    "tracking_number",
+                    "status",
+                    "carrier",
+                    "notify_buyer",
+                    "shipment_date"
+                ],
+                "properties": {
+                    "transaction_id": {
+                        "type": "string"
+                    },
+                    "tracking_number": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "carrier": {
+                        "type": "string"
+                    },
+                    "notify_buyer": {
+                        "type": "boolean"
+                    },
+                    "shipment_date": {
+                        "type": "string",
+                        "format": "date-time"
                     }
                 },
                 "type": "object"
@@ -4530,206 +4199,138 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes": {
+            "paypal_v1_subscription_application_context": {
                 "required": [
-                    "items",
-                    "links"
+                    "brand_name",
+                    "locale",
+                    "return_url",
+                    "cancel_url"
                 ],
                 "properties": {
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item"
-                        },
-                        "nullable": true
+                    "user_action": {
+                        "type": "string",
+                        "default": "SUBSCRIBE_NOW"
                     },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
+                    "brand_name": {
+                        "type": "string"
+                    },
+                    "locale": {
+                        "type": "string"
+                    },
+                    "shipping_preference": {
+                        "type": "string",
+                        "default": "SET_PROVIDED_ADDRESS"
+                    },
+                    "return_url": {
+                        "type": "string"
+                    },
+                    "cancel_url": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_capture_transaction_fee": {
+            "paypal_v1_subscription_billing_info": {
+                "required": [
+                    "outstanding_balance",
+                    "cycle_executions",
+                    "last_payment",
+                    "next_billing_time",
+                    "failed_payments_count"
+                ],
+                "properties": {
+                    "outstanding_balance": {
+                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_outstanding_balance"
+                    },
+                    "cycle_executions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_cycle_execution"
+                        }
+                    },
+                    "last_payment": {
+                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_last_payment"
+                    },
+                    "next_billing_time": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "failed_payments_count": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_billing_info_cycle_execution": {
+                "required": [
+                    "tenure_type",
+                    "sequence",
+                    "cycles_completed",
+                    "cycles_remaining",
+                    "total_cycles"
+                ],
+                "properties": {
+                    "tenure_type": {
+                        "type": "string"
+                    },
+                    "sequence": {
+                        "type": "integer"
+                    },
+                    "cycles_completed": {
+                        "type": "integer"
+                    },
+                    "cycles_remaining": {
+                        "type": "integer"
+                    },
+                    "total_cycles": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_billing_info_last_payment": {
+                "required": [
+                    "amount",
+                    "time"
+                ],
+                "properties": {
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_billing_info_outstanding_balance": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 ]
             },
-            "paypal_v1_merchant_integrations_oauth_integration": {
+            "paypal_v1_subscription_subscriber": {
                 "required": [
-                    "integrationMethod",
-                    "integrationType",
-                    "oauthThirdParty"
+                    "name",
+                    "email_address",
+                    "payer_id",
+                    "shipping_address"
                 ],
                 "properties": {
-                    "integration_method": {
-                        "type": "string"
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_name"
                     },
-                    "integration_type": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "oauth_third_party": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration_oauth_third_party"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_oauth_integration_oauth_third_party": {
-                "required": [
-                    "merchantClientId",
-                    "partnerClientId",
-                    "scopes"
-                ],
-                "properties": {
-                    "access_token": {
-                        "type": "string"
-                    },
-                    "merchant_client_id": {
-                        "type": "string"
-                    },
-                    "partner_client_id": {
-                        "type": "string"
-                    },
-                    "refresh_token": {
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_credentials": {
-                "required": [
-                    "client_id",
-                    "client_secret",
-                    "payer_id"
-                ],
-                "properties": {
-                    "client_id": {
-                        "type": "string"
-                    },
-                    "client_secret": {
+                    "email_address": {
                         "type": "string"
                     },
                     "payer_id": {
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_capability": {
-                "required": [
-                    "name",
-                    "status"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
                     },
-                    "status": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_product": {
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "vetting_status": {
-                        "type": "string"
-                    },
-                    "capabilities": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment": {
-                "required": [
-                    "id",
-                    "state",
-                    "cart",
-                    "payer",
-                    "transactions",
-                    "create_time",
-                    "update_time",
-                    "links",
-                    "redirect_urls",
-                    "application_context",
-                    "payment_instruction"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "intent": {
-                        "type": "string",
-                        "default": "sale",
-                        "enum": [
-                            "sale",
-                            "authorize",
-                            "order"
-                        ]
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "cart": {
-                        "type": "string"
-                    },
-                    "payer": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payer"
-                    },
-                    "transactions": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_payment_transaction"
-                        }
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "redirect_urls": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_redirect_urls"
-                    },
-                    "application_context": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_application_context"
-                    },
-                    "payment_instruction": {
+                    "shipping_address": {
                         "oneOf": [
                             {
-                                "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction"
+                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address"
                             }
                         ],
                         "nullable": true
@@ -4737,64 +4338,926 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_referral": {
+            "paypal_v1_subscription_subscriber_name": {
                 "required": [
-                    "business_entity",
-                    "preferred_language_code",
-                    "tracking_id",
-                    "partner_config_override",
-                    "operations",
-                    "products",
-                    "capabilities",
-                    "legal_consents",
-                    "links",
-                    "legal_country_code"
+                    "given_name",
+                    "surname"
                 ],
                 "properties": {
-                    "business_entity": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_business_entity"
-                    },
-                    "preferred_language_code": {
+                    "given_name": {
                         "type": "string"
                     },
-                    "tracking_id": {
+                    "surname": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_subscriber_shipping_address": {
+                "required": [
+                    "name",
+                    "address"
+                ],
+                "properties": {
+                    "name": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_name"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "address": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_address"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_subscriber_shipping_address_address": {
+                "required": [
+                    "address_line_1",
+                    "address_line_2",
+                    "admin_area_1",
+                    "admin_area_2",
+                    "postal_code",
+                    "country_code"
+                ],
+                "properties": {
+                    "address_line_1": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "address_line_2": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "admin_area_1": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "admin_area_2": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "postal_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "country_code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_subscriber_shipping_address_name": {
+                "required": [
+                    "full_name"
+                ],
+                "properties": {
+                    "full_name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_token": {
+                "required": [
+                    "scope",
+                    "nonce",
+                    "access_token",
+                    "token_type",
+                    "app_id",
+                    "id_token",
+                    "expires_in",
+                    "expire_date_time"
+                ],
+                "properties": {
+                    "scope": {
+                        "description": "Scopes expressed in the form of resource URL endpoints. The value of the scope parameter\nis expressed as a list of space-delimited, case-sensitive strings.",
                         "type": "string"
                     },
-                    "partner_config_override": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_partner_config_override"
+                    "nonce": {
+                        "type": "string"
                     },
-                    "operations": {
+                    "access_token": {
+                        "description": "The access token issued by PayPal. After the access token\nexpires (see $expiresIn), you must request a new access token.",
+                        "type": "string"
+                    },
+                    "token_type": {
+                        "description": "The type of the token issued as described in OAuth2.0 RFC6749,\nSection 7.1. Value is case insensitive.",
+                        "type": "string"
+                    },
+                    "app_id": {
+                        "type": "string"
+                    },
+                    "id_token": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "expires_in": {
+                        "description": "The lifetime of the access token, in seconds.",
+                        "type": "integer"
+                    },
+                    "expire_date_time": {
+                        "description": "Calculated expiration date",
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook": {
+                "required": [
+                    "id",
+                    "url",
+                    "event_types",
+                    "links"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string",
+                        "maxLength": 2048
+                    },
+                    "event_types": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v2_referral_operation"
+                            "$ref": "#/components/schemas/paypal_v1_webhook_event_type"
                         }
                     },
-                    "products": {
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_event": {
+                "required": [
+                    "id",
+                    "resource_type",
+                    "event_type",
+                    "summary",
+                    "resource",
+                    "create_time",
+                    "links",
+                    "event_version",
+                    "resource_version"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "resource_type": {
+                        "type": "string"
+                    },
+                    "event_type": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "resource": {
+                        "nullable": true,
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v3_payment_token"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_webhook_resource"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_subscription"
+                            }
+                        ]
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "event_version": {
+                        "type": "string"
+                    },
+                    "resource_version": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_event_type": {
+                "required": [
+                    "name",
+                    "description",
+                    "status",
+                    "resource_version"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "resource_version": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_resource": {
+                "required": [
+                    "id",
+                    "parent_payment",
+                    "billing_agreement_id",
+                    "sale_id",
+                    "refund_reason_code",
+                    "update_time",
+                    "amount",
+                    "payment_mode",
+                    "create_time",
+                    "clearing_time",
+                    "protection_eligibility_type",
+                    "protection_eligibility",
+                    "transaction_fee",
+                    "invoice_number",
+                    "links",
+                    "state",
+                    "merchant_id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "billing_agreement_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sale_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "refund_reason_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "payment_mode": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "clearing_time": {
+                        "type": "string"
+                    },
+                    "protection_eligibility_type": {
+                        "type": "string"
+                    },
+                    "protection_eligibility": {
+                        "type": "string"
+                    },
+                    "transaction_fee": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "invoice_number": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "merchant_id": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_list": {
+                "required": [
+                    "webhooks"
+                ],
+                "properties": {
+                    "webhooks": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_webhook"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_address": {
+                "required": [
+                    "address_line_1",
+                    "address_line_2",
+                    "admin_area_2",
+                    "admin_area_1",
+                    "postal_code",
+                    "country_code"
+                ],
+                "properties": {
+                    "address_line_1": {
+                        "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 300
+                    },
+                    "address_line_2": {
+                        "description": "The second line of the address. For example, suite or apartment number.",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 300
+                    },
+                    "admin_area_2": {
+                        "description": "A city, town, or village. Smaller than $adminArea1",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 120
+                    },
+                    "admin_area_1": {
+                        "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 300
+                    },
+                    "postal_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 60
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_link": {
+                "required": [
+                    "href",
+                    "rel",
+                    "method",
+                    "enc_type"
+                ],
+                "properties": {
+                    "href": {
+                        "type": "string"
+                    },
+                    "rel": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "type": "string"
+                    },
+                    "enc_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_money": {
+                "required": [
+                    "currency_code",
+                    "value"
+                ],
+                "properties": {
+                    "currency_code": {
+                        "type": "string",
+                        "maxLength": 3,
+                        "minLength": 3
+                    },
+                    "value": {
+                        "type": "string",
+                        "maxLength": 30
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_name": {
+                "required": [
+                    "given_name",
+                    "surname"
+                ],
+                "properties": {
+                    "given_name": {
+                        "type": "string",
+                        "maxLength": 140
+                    },
+                    "surname": {
+                        "type": "string",
+                        "maxLength": 140
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_phone_number": {
+                "required": [
+                    "national_number",
+                    "country_code"
+                ],
+                "properties": {
+                    "national_number": {
+                        "type": "string",
+                        "maxLength": 3,
+                        "minLength": 1
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 14,
+                        "minLength": 1
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_upc": {
+                "required": [
+                    "type",
+                    "code"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "maxLength": 5,
+                        "minLength": 1
+                    },
+                    "code": {
+                        "type": "string",
+                        "maxLength": 17,
+                        "minLength": 6
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_confirm_order": {
+                "required": [
+                    "payment_source"
+                ],
+                "properties": {
+                    "payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data": {
+                "required": [
+                    "eligible_methods",
+                    "supplementary_data"
+                ],
+                "properties": {
+                    "eligible_methods": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods"
+                    },
+                    "supplementary_data": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_supplementary_data"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods": {
+                "required": [
+                    "paypal",
+                    "paypal_pay_later",
+                    "apple_pay",
+                    "google_pay",
+                    "advanced_cards",
+                    "eps",
+                    "p_2_4",
+                    "blik",
+                    "ideal",
+                    "bizum",
+                    "bancontact",
+                    "klarna"
+                ],
+                "properties": {
+                    "paypal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    "paypal_pay_later": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"
+                    },
+                    "apple_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_apple_pay"
+                    },
+                    "google_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_google_pay"
+                    },
+                    "advanced_cards": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"
+                    },
+                    "eps": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_eps"
+                    },
+                    "p_2_4": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_p24"
+                    },
+                    "blik": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_blik"
+                    },
+                    "ideal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_ideal"
+                    },
+                    "bizum": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bizum"
+                    },
+                    "bancontact": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bancontact"
+                    },
+                    "klarna": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_klarna"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards": {
+                "required": [
+                    "supports_installements",
+                    "cobranded_enabled",
+                    "vendors"
+                ],
+                "properties": {
+                    "supports_installements": {
+                        "type": "boolean"
+                    },
+                    "cobranded_enabled": {
+                        "type": "boolean"
+                    },
+                    "vendors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "eligible",
+                            "network",
+                            "branded"
+                        ],
+                        "properties": {
+                            "eligible": {
+                                "type": "boolean"
+                            },
+                            "network": {
+                                "type": "string"
+                            },
+                            "branded": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_apple_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_bancontact": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_bizum": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_blik": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_eps": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_google_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_ideal": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_klarna": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_p24": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal": {
+                "required": [
+                    "can_be_vaulted"
+                ],
+                "properties": {
+                    "can_be_vaulted": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "country_code",
+                            "product_code"
+                        ],
+                        "properties": {
+                            "country_code": {
+                                "description": "ISO 3166-1 alpha-2 country code",
+                                "type": "string",
+                                "maxLength": 2,
+                                "minLength": 2
+                            },
+                            "product_code": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_supplementary_data": {
+                "required": [
+                    "buyer_country_code"
+                ],
+                "properties": {
+                    "buyer_country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods": {
+                "required": [
+                    "customer",
+                    "preferences",
+                    "purchase_units"
+                ],
+                "properties": {
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer"
+                    },
+                    "preferences": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences"
+                    },
+                    "purchase_units": {
+                        "description": "Does not have to be a full purchase unit.\n`[{\"amount\":{\"currency_code\":\"<iso-4217-code>\"},\"payee\":{\"merchant_id\":\"<merchant-id>\"}}]` is enough.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer": {
+                "required": [
+                    "country_code",
+                    "channel"
+                ],
+                "properties": {
+                    "country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "channel": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer_channel"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer_channel": {
+                "required": [
+                    "browser_type",
+                    "client_os",
+                    "device_type"
+                ],
+                "properties": {
+                    "browser_type": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "client_os": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "device_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences": {
+                "required": [
+                    "payment_flow",
+                    "commit",
+                    "intent",
+                    "vault",
+                    "payment_source_constraint"
+                ],
+                "properties": {
+                    "payment_flow": {
+                        "type": "string",
+                        "enum": [
+                            "ONE_TIME_PAYMENT"
+                        ]
+                    },
+                    "commit": {
+                        "type": "boolean"
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": [
+                            "CAPTURE",
+                            "AUTHORIZE"
+                        ]
+                    },
+                    "vault": {
+                        "type": "boolean"
+                    },
+                    "payment_source_constraint": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences_payment_source_constraint"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences_payment_source_constraint": {
+                "required": [
+                    "constraint_type",
+                    "payment_sources"
+                ],
+                "properties": {
+                    "constraint_type": {
+                        "type": "string",
+                        "enum": [
+                            "INCLUDE"
+                        ]
+                    },
+                    "payment_sources": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order": {
+                "required": [
+                    "create_time",
+                    "update_time",
+                    "id",
+                    "intent",
+                    "payer",
+                    "purchase_units",
+                    "application_context",
+                    "payment_source",
+                    "status",
+                    "processing_instruction",
+                    "links"
+                ],
+                "properties": {
+                    "create_time": {
+                        "type": "string"
                     },
-                    "capabilities": {
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": [
+                            "CAPTURE",
+                            "AUTHORIZE"
+                        ]
+                    },
+                    "payer": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payer"
+                    },
+                    "purchase_units": {
                         "type": "array",
                         "items": {
-                            "type": "string"
-                        }
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                        },
+                        "nullable": true
                     },
-                    "legal_consents": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_referral_legal_consent"
-                        }
+                    "application_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_application_context"
+                    },
+                    "payment_source": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "processing_instruction": {
+                        "type": "string"
                     },
                     "links": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
-                    },
-                    "legal_country_code": {
-                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -4840,1187 +5303,6 @@
                     },
                     "cancel_url": {
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_tracker": {
-                "required": [
-                    "capture_id",
-                    "tracking_number",
-                    "carrier",
-                    "carrier_name_other",
-                    "items"
-                ],
-                "properties": {
-                    "capture_id": {
-                        "type": "string"
-                    },
-                    "tracking_number": {
-                        "type": "string",
-                        "maxLength": 64
-                    },
-                    "carrier": {
-                        "type": "string"
-                    },
-                    "carrier_name_other": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "notify_payer": {
-                        "type": "boolean",
-                        "default": false
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker_item"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit": {
-                "required": [
-                    "reference_id",
-                    "amount",
-                    "payee",
-                    "description",
-                    "custom_id",
-                    "invoice_id",
-                    "items",
-                    "shipping",
-                    "payments",
-                    "supplementary_data",
-                    "shipping_options"
-                ],
-                "properties": {
-                    "reference_id": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount"
-                    },
-                    "payee": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "custom_id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "invoice_id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
-                        },
-                        "nullable": true
-                    },
-                    "shipping": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping"
-                    },
-                    "payments": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "supplementary_data": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data"
-                    },
-                    "shipping_options": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_google_pay": {
-                "required": [
-                    "experience_context",
-                    "card",
-                    "attributes"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "card": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_afterpay": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email",
-                    "phone",
-                    "birth_date"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "type": "string"
-                    },
-                    "birth_date": {
-                        "type": "string",
-                        "format": "date"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_oxxo": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_klarna": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email",
-                    "phone"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_blik": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_token_stored_payment_source": {
-                "required": [
-                    "payment_initiator",
-                    "payment_type",
-                    "usage"
-                ],
-                "properties": {
-                    "payment_initiator": {
-                        "type": "string"
-                    },
-                    "payment_type": {
-                        "type": "string"
-                    },
-                    "usage": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_pay_upon_invoice": {
-                "required": [
-                    "experience_context",
-                    "name",
-                    "email",
-                    "birth_date",
-                    "phone",
-                    "billing_address",
-                    "payment_reference",
-                    "deposit_bank_details"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_common_name"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "birth_date": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                    },
-                    "billing_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "payment_reference": {
-                        "type": "string"
-                    },
-                    "deposit_bank_details": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_boletobancario_tax_info": {
-                "required": [
-                    "tax_id",
-                    "tax_id_type"
-                ],
-                "properties": {
-                    "tax_id": {
-                        "type": "string"
-                    },
-                    "tax_id_type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_eps": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_token": {
-                "required": [
-                    "experience_context",
-                    "id",
-                    "type",
-                    "stored_payment_source"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "stored_payment_source": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_token_stored_payment_source"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_p24": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card_stored_credential": {
-                "required": [
-                    "payment_initiator",
-                    "payment_type",
-                    "usage",
-                    "previous_network_transaction_reference"
-                ],
-                "properties": {
-                    "payment_initiator": {
-                        "type": "string",
-                        "enum": [
-                            "MERCHANT",
-                            "CUSTOMER"
-                        ]
-                    },
-                    "payment_type": {
-                        "type": "string",
-                        "enum": [
-                            "RECURRING",
-                            "ONE_TIME",
-                            "UNSCHEDULED"
-                        ]
-                    },
-                    "usage": {
-                        "type": "string",
-                        "enum": [
-                            "DERIVED",
-                            "FIRST",
-                            "SUBSEQUENT"
-                        ]
-                    },
-                    "previous_network_transaction_reference": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card_authentication_result": {
-                "required": [
-                    "liability_shift",
-                    "three_d_secure"
-                ],
-                "properties": {
-                    "liability_shift": {
-                        "type": "string"
-                    },
-                    "three_d_secure": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result_3d_secure"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card_authentication_result_3d_secure": {
-                "required": [
-                    "enrollment_status",
-                    "authentication_status"
-                ],
-                "properties": {
-                    "enrollment_status": {
-                        "type": "string"
-                    },
-                    "authentication_status": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_phone": {
-                "required": [
-                    "phone_type",
-                    "phone_number"
-                ],
-                "properties": {
-                    "phone_type": {
-                        "type": "string"
-                    },
-                    "phone_number": {
-                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_customer": {
-                "required": [
-                    "id"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_vault": {
-                "required": [
-                    "id",
-                    "store_in_vault",
-                    "usage_type",
-                    "status",
-                    "confirm_payment_token",
-                    "permit_multiple_payment_tokens",
-                    "customer",
-                    "links"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "store_in_vault": {
-                        "type": "string"
-                    },
-                    "usage_type": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "confirm_payment_token": {
-                        "type": "string"
-                    },
-                    "permit_multiple_payment_tokens": {
-                        "type": "boolean"
-                    },
-                    "customer": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_order_update_callback_config": {
-                "required": [
-                    "callback_url",
-                    "callback_events"
-                ],
-                "properties": {
-                    "callback_url": {
-                        "type": "string"
-                    },
-                    "callback_events": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "enum": [
-                                "SHIPPING_ADDRESS",
-                                "SHIPPING_OPTIONS"
-                            ]
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_verification": {
-                "required": [
-                    "method"
-                ],
-                "properties": {
-                    "method": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context": {
-                "required": [
-                    "buyer_user_agent"
-                ],
-                "properties": {
-                    "return_flow": {
-                        "type": "string",
-                        "default": "AUTO",
-                        "enum": [
-                            "AUTO",
-                            "MANUAL"
-                        ]
-                    },
-                    "buyer_user_agent": {
-                        "type": "string",
-                        "maxLength": 512,
-                        "minLength": 1
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_app_switch_context_native_app_context": {
-                "required": [
-                    "os_type",
-                    "os_version"
-                ],
-                "properties": {
-                    "os_type": {
-                        "type": "string",
-                        "enum": [
-                            "ANDROID",
-                            "IOS",
-                            "OTHER"
-                        ]
-                    },
-                    "os_version": {
-                        "type": "string",
-                        "maxLength": 64,
-                        "minLength": 1
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_app_switch_context": {
-                "required": [
-                    "native_app",
-                    "mobile_web"
-                ],
-                "properties": {
-                    "native_app": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_native_app_context"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "mobile_web": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_experience_context": {
-                "required": [
-                    "locale",
-                    "brand_name",
-                    "logo_url",
-                    "return_url",
-                    "cancel_url",
-                    "payment_method_preference",
-                    "customer_service_instructions",
-                    "order_update_callback_config",
-                    "app_switch_context"
-                ],
-                "properties": {
-                    "locale": {
-                        "type": "string"
-                    },
-                    "brand_name": {
-                        "type": "string"
-                    },
-                    "logo_url": {
-                        "type": "string"
-                    },
-                    "landing_page": {
-                        "type": "string",
-                        "default": "NO_PREFERENCE",
-                        "enum": [
-                            "LOGIN",
-                            "GUEST_CHECKOUT",
-                            "NO_PREFERENCE"
-                        ]
-                    },
-                    "shipping_preference": {
-                        "type": "string",
-                        "default": "SET_PROVIDED_ADDRESS",
-                        "enum": [
-                            "SET_PROVIDED_ADDRESS",
-                            "NO_SHIPPING",
-                            "GET_FROM_FILE"
-                        ]
-                    },
-                    "user_action": {
-                        "type": "string",
-                        "default": "PAY_NOW",
-                        "enum": [
-                            "CONTINUE",
-                            "PAY_NOW"
-                        ]
-                    },
-                    "return_url": {
-                        "type": "string"
-                    },
-                    "cancel_url": {
-                        "type": "string"
-                    },
-                    "payment_method_preference": {
-                        "description": "Only: PayPal Wallet",
-                        "type": "string",
-                        "enum": [
-                            "UNRESTRICTED",
-                            "IMMEDIATE_PAYMENT_REQUIRED"
-                        ]
-                    },
-                    "customer_service_instructions": {
-                        "description": "Only: PUI",
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "order_update_callback_config": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_order_update_callback_config"
-                    },
-                    "app_switch_context": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes": {
-                "required": [
-                    "vault",
-                    "customer",
-                    "verification"
-                ],
-                "properties": {
-                    "vault": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_vault"
-                    },
-                    "customer": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
-                    },
-                    "verification": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_verification"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_bancontact": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_my_bank": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_trustly": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_paypal": {
-                "required": [
-                    "experience_context",
-                    "email_address",
-                    "account_id",
-                    "billing_agreement_id",
-                    "vault_id",
-                    "name",
-                    "phone_number",
-                    "address",
-                    "birth_date",
-                    "phone_type",
-                    "attributes"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email_address": {
-                        "type": "string"
-                    },
-                    "account_id": {
-                        "type": "string"
-                    },
-                    "billing_agreement_id": {
-                        "type": "string"
-                    },
-                    "vault_id": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_common_name"
-                    },
-                    "phone_number": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "birth_date": {
-                        "type": "string"
-                    },
-                    "phone_type": {
-                        "type": "string"
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details": {
-                "required": [
-                    "bic",
-                    "bank_name",
-                    "iban",
-                    "account_holder_name"
-                ],
-                "properties": {
-                    "bic": {
-                        "type": "string"
-                    },
-                    "bank_name": {
-                        "type": "string"
-                    },
-                    "iban": {
-                        "type": "string"
-                    },
-                    "account_holder_name": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_boletobancario": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email",
-                    "expiry_date",
-                    "tax_info",
-                    "billing_address"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "expiry_date": {
-                        "type": "string"
-                    },
-                    "tax_info": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_boletobancario_tax_info"
-                    },
-                    "billing_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "last_digits",
-                    "brand",
-                    "type",
-                    "vault_id",
-                    "billing_address",
-                    "authentication_result",
-                    "attributes",
-                    "stored_credential"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "last_digits": {
-                        "type": "string"
-                    },
-                    "brand": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "vault_id": {
-                        "type": "string"
-                    },
-                    "billing_address": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_address"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "authentication_result": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "stored_credential": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_stored_credential"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_ideal": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_swish": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "phone"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "phone": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_venmo": {
-                "required": [
-                    "experience_context",
-                    "email_address",
-                    "user_name",
-                    "account_id",
-                    "vault_id",
-                    "name",
-                    "phone_number",
-                    "address",
-                    "attributes"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email_address": {
-                        "type": "string"
-                    },
-                    "user_name": {
-                        "type": "string"
-                    },
-                    "account_id": {
-                        "type": "string"
-                    },
-                    "vault_id": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_common_name"
-                    },
-                    "phone_number": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_apple_pay": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "card",
-                    "attributes"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "card": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_multibanco": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
                     }
                 },
                 "type": "object"
@@ -6239,24 +5521,1175 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payee": {
+            "paypal_v2_order_payment_source_afterpay": {
                 "required": [
-                    "email_address",
-                    "merchant_id",
-                    "display_data"
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone",
+                    "birth_date"
                 ],
                 "properties": {
-                    "email_address": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
                         "type": "string"
                     },
-                    "merchant_id": {
+                    "phone": {
                         "type": "string"
                     },
-                    "display_data": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee_display_data"
+                    "birth_date": {
+                        "type": "string",
+                        "format": "date"
                     }
                 },
                 "type": "object"
+            },
+            "paypal_v2_order_payment_source_apple_pay": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "card",
+                    "attributes"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "card": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_bancontact": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_blik": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_boletobancario": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "expiry_date",
+                    "tax_info",
+                    "billing_address"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "expiry_date": {
+                        "type": "string"
+                    },
+                    "tax_info": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_boletobancario_tax_info"
+                    },
+                    "billing_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_boletobancario_tax_info": {
+                "required": [
+                    "tax_id",
+                    "tax_id_type"
+                ],
+                "properties": {
+                    "tax_id": {
+                        "type": "string"
+                    },
+                    "tax_id_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "last_digits",
+                    "brand",
+                    "type",
+                    "vault_id",
+                    "billing_address",
+                    "authentication_result",
+                    "attributes",
+                    "stored_credential"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "last_digits": {
+                        "type": "string"
+                    },
+                    "brand": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "vault_id": {
+                        "type": "string"
+                    },
+                    "billing_address": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_address"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "authentication_result": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "stored_credential": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_stored_credential"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card_authentication_result": {
+                "required": [
+                    "liability_shift",
+                    "three_d_secure"
+                ],
+                "properties": {
+                    "liability_shift": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "three_d_secure": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result_3d_secure"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card_authentication_result_3d_secure": {
+                "required": [
+                    "enrollment_status",
+                    "authentication_status"
+                ],
+                "properties": {
+                    "enrollment_status": {
+                        "type": "string"
+                    },
+                    "authentication_status": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card_stored_credential": {
+                "required": [
+                    "payment_initiator",
+                    "payment_type",
+                    "usage",
+                    "previous_network_transaction_reference"
+                ],
+                "properties": {
+                    "payment_initiator": {
+                        "type": "string",
+                        "enum": [
+                            "MERCHANT",
+                            "CUSTOMER"
+                        ]
+                    },
+                    "payment_type": {
+                        "type": "string",
+                        "enum": [
+                            "RECURRING",
+                            "ONE_TIME",
+                            "UNSCHEDULED"
+                        ]
+                    },
+                    "usage": {
+                        "type": "string",
+                        "enum": [
+                            "DERIVED",
+                            "FIRST",
+                            "SUBSEQUENT"
+                        ]
+                    },
+                    "previous_network_transaction_reference": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_app_switch_context": {
+                "required": [
+                    "native_app",
+                    "mobile_web"
+                ],
+                "properties": {
+                    "native_app": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_native_app_context"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "mobile_web": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context": {
+                "required": [
+                    "buyer_user_agent"
+                ],
+                "properties": {
+                    "return_flow": {
+                        "type": "string",
+                        "default": "AUTO",
+                        "enum": [
+                            "AUTO",
+                            "MANUAL"
+                        ]
+                    },
+                    "buyer_user_agent": {
+                        "type": "string",
+                        "maxLength": 512,
+                        "minLength": 1
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_app_switch_context_native_app_context": {
+                "required": [
+                    "os_type",
+                    "os_version"
+                ],
+                "properties": {
+                    "os_type": {
+                        "type": "string",
+                        "enum": [
+                            "ANDROID",
+                            "IOS",
+                            "OTHER"
+                        ]
+                    },
+                    "os_version": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "minLength": 1
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes": {
+                "required": [
+                    "vault",
+                    "customer",
+                    "verification"
+                ],
+                "properties": {
+                    "vault": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_vault"
+                    },
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
+                    },
+                    "verification": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_verification"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_customer": {
+                "required": [
+                    "id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_order_update_callback_config": {
+                "required": [
+                    "callback_url",
+                    "callback_events"
+                ],
+                "properties": {
+                    "callback_url": {
+                        "type": "string"
+                    },
+                    "callback_events": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "SHIPPING_ADDRESS",
+                                "SHIPPING_OPTIONS"
+                            ]
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_vault": {
+                "required": [
+                    "id",
+                    "store_in_vault",
+                    "usage_type",
+                    "status",
+                    "confirm_payment_token",
+                    "permit_multiple_payment_tokens",
+                    "customer",
+                    "links"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "store_in_vault": {
+                        "type": "string"
+                    },
+                    "usage_type": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "confirm_payment_token": {
+                        "type": "string"
+                    },
+                    "permit_multiple_payment_tokens": {
+                        "type": "boolean"
+                    },
+                    "customer": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_verification": {
+                "required": [
+                    "method"
+                ],
+                "properties": {
+                    "method": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_experience_context": {
+                "required": [
+                    "locale",
+                    "brand_name",
+                    "logo_url",
+                    "return_url",
+                    "cancel_url",
+                    "payment_method_preference",
+                    "customer_service_instructions",
+                    "order_update_callback_config",
+                    "app_switch_context"
+                ],
+                "properties": {
+                    "locale": {
+                        "type": "string"
+                    },
+                    "brand_name": {
+                        "type": "string"
+                    },
+                    "logo_url": {
+                        "type": "string"
+                    },
+                    "landing_page": {
+                        "type": "string",
+                        "default": "NO_PREFERENCE",
+                        "enum": [
+                            "LOGIN",
+                            "GUEST_CHECKOUT",
+                            "NO_PREFERENCE"
+                        ]
+                    },
+                    "shipping_preference": {
+                        "type": "string",
+                        "default": "SET_PROVIDED_ADDRESS",
+                        "enum": [
+                            "SET_PROVIDED_ADDRESS",
+                            "NO_SHIPPING",
+                            "GET_FROM_FILE"
+                        ]
+                    },
+                    "user_action": {
+                        "type": "string",
+                        "default": "PAY_NOW",
+                        "enum": [
+                            "CONTINUE",
+                            "PAY_NOW"
+                        ]
+                    },
+                    "return_url": {
+                        "type": "string"
+                    },
+                    "cancel_url": {
+                        "type": "string"
+                    },
+                    "payment_method_preference": {
+                        "description": "Only: PayPal Wallet",
+                        "type": "string",
+                        "enum": [
+                            "UNRESTRICTED",
+                            "IMMEDIATE_PAYMENT_REQUIRED"
+                        ]
+                    },
+                    "customer_service_instructions": {
+                        "description": "Only: PUI",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "order_update_callback_config": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_order_update_callback_config"
+                    },
+                    "app_switch_context": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_phone": {
+                "required": [
+                    "phone_type",
+                    "phone_number"
+                ],
+                "properties": {
+                    "phone_type": {
+                        "type": "string"
+                    },
+                    "phone_number": {
+                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_eps": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_google_pay": {
+                "required": [
+                    "experience_context",
+                    "card",
+                    "attributes"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "card": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_ideal": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_klarna": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_multibanco": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_my_bank": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_oxxo": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_p24": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_pay_upon_invoice": {
+                "required": [
+                    "experience_context",
+                    "name",
+                    "email",
+                    "birth_date",
+                    "phone",
+                    "billing_address",
+                    "payment_reference",
+                    "deposit_bank_details"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v2_common_name"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "birth_date": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                    },
+                    "billing_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "payment_reference": {
+                        "type": "string"
+                    },
+                    "deposit_bank_details": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details": {
+                "required": [
+                    "bic",
+                    "bank_name",
+                    "iban",
+                    "account_holder_name"
+                ],
+                "properties": {
+                    "bic": {
+                        "type": "string"
+                    },
+                    "bank_name": {
+                        "type": "string"
+                    },
+                    "iban": {
+                        "type": "string"
+                    },
+                    "account_holder_name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_paypal": {
+                "required": [
+                    "experience_context",
+                    "email_address",
+                    "account_id",
+                    "billing_agreement_id",
+                    "vault_id",
+                    "name",
+                    "phone_number",
+                    "address",
+                    "birth_date",
+                    "phone_type",
+                    "attributes"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email_address": {
+                        "type": "string"
+                    },
+                    "account_id": {
+                        "type": "string"
+                    },
+                    "billing_agreement_id": {
+                        "type": "string"
+                    },
+                    "vault_id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v2_common_name"
+                    },
+                    "phone_number": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "birth_date": {
+                        "type": "string"
+                    },
+                    "phone_type": {
+                        "type": "string"
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_swish": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "phone": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_token": {
+                "required": [
+                    "experience_context",
+                    "id",
+                    "type",
+                    "stored_payment_source"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "stored_payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_token_stored_payment_source"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_token_stored_payment_source": {
+                "required": [
+                    "payment_initiator",
+                    "payment_type",
+                    "usage"
+                ],
+                "properties": {
+                    "payment_initiator": {
+                        "type": "string"
+                    },
+                    "payment_type": {
+                        "type": "string"
+                    },
+                    "usage": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_trustly": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_venmo": {
+                "required": [
+                    "experience_context",
+                    "email_address",
+                    "user_name",
+                    "account_id",
+                    "vault_id",
+                    "name",
+                    "phone_number",
+                    "address",
+                    "attributes"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email_address": {
+                        "type": "string"
+                    },
+                    "user_name": {
+                        "type": "string"
+                    },
+                    "account_id": {
+                        "type": "string"
+                    },
+                    "vault_id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v2_common_name"
+                    },
+                    "phone_number": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit": {
+                "required": [
+                    "reference_id",
+                    "amount",
+                    "payee",
+                    "description",
+                    "custom_id",
+                    "invoice_id",
+                    "items",
+                    "shipping",
+                    "payments",
+                    "supplementary_data",
+                    "shipping_options"
+                ],
+                "properties": {
+                    "reference_id": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount"
+                    },
+                    "payee": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "custom_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "invoice_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
+                        },
+                        "nullable": true
+                    },
+                    "shipping": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping"
+                    },
+                    "payments": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "supplementary_data": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data"
+                    },
+                    "shipping_options": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_amount": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    {
+                        "required": [
+                            "breakdown"
+                        ],
+                        "properties": {
+                            "breakdown": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount_breakdown"
+                                    }
+                                ],
+                                "nullable": true
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
             },
             "paypal_v2_order_purchase_unit_amount_breakdown": {
                 "required": [
@@ -6294,6 +6727,190 @@
                     },
                     "discount": {
                         "$ref": "#/components/schemas/paypal_v2_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_item": {
+                "required": [
+                    "name",
+                    "unit_amount",
+                    "tax",
+                    "tax_rate",
+                    "category",
+                    "quantity",
+                    "sku"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 120
+                    },
+                    "unit_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "tax": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "tax_rate": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "float"
+                            }
+                        ]
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "PHYSICAL_GOODS",
+                            "DIGITAL_GOODS",
+                            "DONATION"
+                        ]
+                    },
+                    "quantity": {
+                        "type": "integer"
+                    },
+                    "sku": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 127
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payee": {
+                "required": [
+                    "email_address",
+                    "merchant_id",
+                    "display_data"
+                ],
+                "properties": {
+                    "email_address": {
+                        "type": "string"
+                    },
+                    "merchant_id": {
+                        "type": "string"
+                    },
+                    "display_data": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee_display_data"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payee_display_data": {
+                "required": [
+                    "brand_name"
+                ],
+                "properties": {
+                    "brand_name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments": {
+                "required": [
+                    "authorizations",
+                    "captures",
+                    "refunds"
+                ],
+                "properties": {
+                    "authorizations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
+                        },
+                        "nullable": true
+                    },
+                    "captures": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
+                        },
+                        "nullable": true
+                    },
+                    "refunds": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_authorization": {
+                "required": [
+                    "status",
+                    "id",
+                    "amount",
+                    "custom_id",
+                    "links",
+                    "create_time",
+                    "update_time",
+                    "seller_protection",
+                    "expiration_time"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_money"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "custom_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "seller_protection": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
+                    },
+                    "expiration_time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_authorization_seller_protection": {
+                "required": [
+                    "status",
+                    "dispute_categories"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "dispute_categories": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 },
                 "type": "object"
@@ -6374,6 +6991,65 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_order_purchase_unit_payments_capture_processor_response": {
+                "required": [
+                    "avs_code",
+                    "cvv_code",
+                    "response_code"
+                ],
+                "properties": {
+                    "avs_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cvv_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "response_code": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown": {
+                "required": [
+                    "gross_amount",
+                    "paypal_fee",
+                    "net_amount"
+                ],
+                "properties": {
+                    "gross_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "paypal_fee": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "net_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_common_seller_protection": {
+                "required": [
+                    "status",
+                    "dispute_categories"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "dispute_categories": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order_purchase_unit_payments_refund": {
                 "required": [
                     "status",
@@ -6434,76 +7110,6 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payments_authorization": {
-                "required": [
-                    "status",
-                    "id",
-                    "amount",
-                    "custom_id",
-                    "links",
-                    "create_time",
-                    "update_time",
-                    "seller_protection",
-                    "expiration_time"
-                ],
-                "properties": {
-                    "status": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_money"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "custom_id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "seller_protection": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
-                    },
-                    "expiration_time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments_common_seller_protection": {
-                "required": [
-                    "status",
-                    "dispute_categories"
-                ],
-                "properties": {
-                    "status": {
-                        "type": "string"
-                    },
-                    "dispute_categories": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
             "paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown": {
                 "required": [
                     "gross_amount",
@@ -6527,160 +7133,25 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payments_authorization_seller_protection": {
-                "required": [
-                    "status",
-                    "dispute_categories"
-                ],
-                "properties": {
-                    "status": {
-                        "type": "string"
-                    },
-                    "dispute_categories": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments_capture_processor_response": {
-                "required": [
-                    "avs_code",
-                    "cvv_code",
-                    "response_code"
-                ],
-                "properties": {
-                    "avs_code": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "cvv_code": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "response_code": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown": {
-                "required": [
-                    "gross_amount",
-                    "paypal_fee",
-                    "net_amount"
-                ],
-                "properties": {
-                    "gross_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "paypal_fee": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "net_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_item": {
+            "paypal_v2_order_purchase_unit_shipping": {
                 "required": [
                     "name",
-                    "unit_amount",
-                    "tax",
-                    "tax_rate",
-                    "category",
-                    "quantity",
-                    "sku"
+                    "address",
+                    "trackers"
                 ],
                 "properties": {
                     "name": {
-                        "type": "string",
-                        "maxLength": 120
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_name"
                     },
-                    "unit_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
                     },
-                    "tax": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "tax_rate": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "float"
-                            }
-                        ]
-                    },
-                    "category": {
-                        "type": "string",
-                        "enum": [
-                            "PHYSICAL_GOODS",
-                            "DIGITAL_GOODS",
-                            "DONATION"
-                        ]
-                    },
-                    "quantity": {
-                        "type": "integer"
-                    },
-                    "sku": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 127
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments": {
-                "required": [
-                    "authorizations",
-                    "captures",
-                    "refunds"
-                ],
-                "properties": {
-                    "authorizations": {
+                    "trackers": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker"
                         },
                         "nullable": true
-                    },
-                    "captures": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
-                        },
-                        "nullable": true
-                    },
-                    "refunds": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_supplementary_data": {
-                "required": [
-                    "card",
-                    "risk"
-                ],
-                "properties": {
-                    "card": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card"
-                    },
-                    "risk": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk"
                     }
                 },
                 "type": "object"
@@ -6692,6 +7163,39 @@
                 "properties": {
                     "full_name": {
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_shipping_tracker": {
+                "required": [
+                    "id",
+                    "status",
+                    "notify_payer",
+                    "links",
+                    "items"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "notify_payer": {
+                        "type": "boolean"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
+                        }
                     }
                 },
                 "type": "object"
@@ -6730,39 +7234,6 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_shipping_tracker": {
-                "required": [
-                    "id",
-                    "status",
-                    "notify_payer",
-                    "links",
-                    "items"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "notify_payer": {
-                        "type": "boolean"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
-                        }
-                    }
-                },
-                "type": "object"
-            },
             "paypal_v2_order_purchase_unit_shipping_option": {
                 "required": [
                     "id",
@@ -6794,71 +7265,77 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payee_display_data": {
+            "paypal_v2_order_purchase_unit_supplementary_data": {
                 "required": [
-                    "brand_name"
+                    "card",
+                    "risk"
                 ],
                 "properties": {
-                    "brand_name": {
-                        "type": "string"
+                    "card": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card"
+                    },
+                    "risk": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_amount": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    {
-                        "required": [
-                            "breakdown"
-                        ],
-                        "properties": {
-                            "breakdown": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount_breakdown"
-                                    }
-                                ],
-                                "nullable": true
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_order_purchase_unit_shipping": {
-                "required": [
-                    "name",
-                    "address",
-                    "trackers"
-                ],
-                "properties": {
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_name"
-                    },
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "trackers": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_supplementary_data_risk": {
+            "paypal_v2_order_purchase_unit_supplementary_data_card": {
                 "required": [
                     "address"
                 ],
                 "properties": {
                     "address": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk_participant_metadata"
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_level2"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_supplementary_data_card_level2": {
+                "required": [
+                    "invoice_id",
+                    "tax_total"
+                ],
+                "properties": {
+                    "invoice_id": {
+                        "type": "string"
+                    },
+                    "tax_total": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_supplementary_data_card_level3": {
+                "required": [
+                    "shipping_amount",
+                    "duty_amount",
+                    "discount_amount",
+                    "shipping_address",
+                    "ships_from_postal_code",
+                    "line_items"
+                ],
+                "properties": {
+                    "shipping_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "duty_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "discount_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "ships_from_postal_code": {
+                        "type": "string"
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_line_item"
+                        }
                     }
                 },
                 "type": "object"
@@ -6934,51 +7411,13 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_supplementary_data_card_level2": {
+            "paypal_v2_order_purchase_unit_supplementary_data_risk": {
                 "required": [
-                    "invoice_id",
-                    "tax_total"
+                    "address"
                 ],
                 "properties": {
-                    "invoice_id": {
-                        "type": "string"
-                    },
-                    "tax_total": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_supplementary_data_card_level3": {
-                "required": [
-                    "shipping_amount",
-                    "duty_amount",
-                    "discount_amount",
-                    "shipping_address",
-                    "ships_from_postal_code",
-                    "line_items"
-                ],
-                "properties": {
-                    "shipping_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "duty_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "discount_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "shipping_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "ships_from_postal_code": {
-                        "type": "string"
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_line_item"
-                        }
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk_participant_metadata"
                     }
                 },
                 "type": "object"
@@ -6996,482 +7435,64 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_supplementary_data_card": {
+            "paypal_v2_order_tracker": {
                 "required": [
-                    "address"
+                    "capture_id",
+                    "tracking_number",
+                    "carrier",
+                    "carrier_name_other",
+                    "items"
                 ],
                 "properties": {
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_level2"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data": {
-                "required": [
-                    "eligible_methods",
-                    "supplementary_data"
-                ],
-                "properties": {
-                    "eligible_methods": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods"
+                    "capture_id": {
+                        "type": "string"
                     },
-                    "supplementary_data": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_supplementary_data"
+                    "tracking_number": {
+                        "type": "string",
+                        "maxLength": 64
+                    },
+                    "carrier": {
+                        "type": "string"
+                    },
+                    "carrier_name_other": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "notify_payer": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker_item"
+                        }
                     }
                 },
                 "type": "object"
             },
-            "paypal_v2_find_eligible_methods": {
+            "paypal_v2_order_shipping_callback": {
                 "required": [
-                    "customer",
-                    "preferences",
+                    "id",
+                    "shipping_address",
+                    "shipping_option",
                     "purchase_units"
                 ],
                 "properties": {
-                    "customer": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer"
-                    },
-                    "preferences": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences"
-                    },
-                    "purchase_units": {
-                        "description": "Does not have to be a full purchase unit.\n`[{\"amount\":{\"currency_code\":\"<iso-4217-code>\"},\"payee\":{\"merchant_id\":\"<merchant-id>\"}}]` is enough.",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_google_pay": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "config"
-                        ],
-                        "properties": {
-                            "config": {
-                                "type": "array",
-                                "items": {
-                                    "type": "mixed"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_klarna": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_blik": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards": {
-                "required": [
-                    "supports_installements",
-                    "cobranded_enabled",
-                    "vendors"
-                ],
-                "properties": {
-                    "supports_installements": {
-                        "type": "boolean"
-                    },
-                    "cobranded_enabled": {
-                        "type": "boolean"
-                    },
-                    "vendors": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_bizum": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_eps": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_p24": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "eligible",
-                            "network",
-                            "branded"
-                        ],
-                        "properties": {
-                            "eligible": {
-                                "type": "boolean"
-                            },
-                            "network": {
-                                "type": "string"
-                            },
-                            "branded": {
-                                "type": "boolean"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "country_code",
-                            "product_code"
-                        ],
-                        "properties": {
-                            "country_code": {
-                                "description": "ISO 3166-1 alpha-2 country code",
-                                "type": "string",
-                                "maxLength": 2,
-                                "minLength": 2
-                            },
-                            "product_code": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_bancontact": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_paypal": {
-                "required": [
-                    "can_be_vaulted"
-                ],
-                "properties": {
-                    "can_be_vaulted": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_ideal": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_apple_pay": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "config"
-                        ],
-                        "properties": {
-                            "config": {
-                                "type": "array",
-                                "items": {
-                                    "type": "mixed"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_supplementary_data": {
-                "required": [
-                    "buyer_country_code"
-                ],
-                "properties": {
-                    "buyer_country_code": {
-                        "description": "ISO 3166-1 alpha-2 country code",
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods": {
-                "required": [
-                    "paypal",
-                    "paypal_pay_later",
-                    "apple_pay",
-                    "google_pay",
-                    "advanced_cards",
-                    "eps",
-                    "p_2_4",
-                    "blik",
-                    "ideal",
-                    "bizum",
-                    "bancontact",
-                    "klarna"
-                ],
-                "properties": {
-                    "paypal": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    "paypal_pay_later": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"
-                    },
-                    "apple_pay": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_apple_pay"
-                    },
-                    "google_pay": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_google_pay"
-                    },
-                    "advanced_cards": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"
-                    },
-                    "eps": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_eps"
-                    },
-                    "p_2_4": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_p24"
-                    },
-                    "blik": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_blik"
-                    },
-                    "ideal": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_ideal"
-                    },
-                    "bizum": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bizum"
-                    },
-                    "bancontact": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bancontact"
-                    },
-                    "klarna": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_klarna"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order": {
-                "required": [
-                    "create_time",
-                    "update_time",
-                    "id",
-                    "intent",
-                    "payer",
-                    "purchase_units",
-                    "application_context",
-                    "payment_source",
-                    "status",
-                    "processing_instruction",
-                    "links"
-                ],
-                "properties": {
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
                     "id": {
                         "type": "string"
                     },
-                    "intent": {
-                        "type": "string",
-                        "enum": [
-                            "CAPTURE",
-                            "AUTHORIZE"
-                        ]
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
                     },
-                    "payer": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payer"
+                    "shipping_option": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
                     },
                     "purchase_units": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
-                        },
-                        "nullable": true
-                    },
-                    "application_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_application_context"
-                    },
-                    "payment_source": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "processing_instruction": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_name": {
-                "required": [
-                    "given_name",
-                    "surname"
-                ],
-                "properties": {
-                    "given_name": {
-                        "type": "string",
-                        "maxLength": 140
-                    },
-                    "surname": {
-                        "type": "string",
-                        "maxLength": 140
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_phone_number": {
-                "required": [
-                    "national_number",
-                    "country_code"
-                ],
-                "properties": {
-                    "national_number": {
-                        "type": "string",
-                        "maxLength": 3,
-                        "minLength": 1
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 14,
-                        "minLength": 1
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_link": {
-                "required": [
-                    "href",
-                    "rel",
-                    "method",
-                    "enc_type"
-                ],
-                "properties": {
-                    "href": {
-                        "type": "string"
-                    },
-                    "rel": {
-                        "type": "string"
-                    },
-                    "method": {
-                        "type": "string"
-                    },
-                    "enc_type": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_upc": {
-                "required": [
-                    "type",
-                    "code"
-                ],
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "maxLength": 5,
-                        "minLength": 1
-                    },
-                    "code": {
-                        "type": "string",
-                        "maxLength": 17,
-                        "minLength": 6
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_address": {
-                "required": [
-                    "address_line_1",
-                    "address_line_2",
-                    "admin_area_2",
-                    "admin_area_1",
-                    "postal_code",
-                    "country_code"
-                ],
-                "properties": {
-                    "address_line_1": {
-                        "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 300
-                    },
-                    "address_line_2": {
-                        "description": "The second line of the address. For example, suite or apartment number.",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 300
-                    },
-                    "admin_area_2": {
-                        "description": "A city, town, or village. Smaller than $adminArea1",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 120
-                    },
-                    "admin_area_1": {
-                        "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 300
-                    },
-                    "postal_code": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 60
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_money": {
-                "required": [
-                    "currency_code",
-                    "value"
-                ],
-                "properties": {
-                    "currency_code": {
-                        "type": "string",
-                        "maxLength": 3,
-                        "minLength": 3
-                    },
-                    "value": {
-                        "type": "string",
-                        "maxLength": 30
                     }
                 },
                 "type": "object"
@@ -7519,31 +7540,63 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_referral_operation": {
+            "paypal_v2_referral": {
                 "required": [
-                    "api_integration_preference"
+                    "business_entity",
+                    "preferred_language_code",
+                    "tracking_id",
+                    "partner_config_override",
+                    "operations",
+                    "products",
+                    "capabilities",
+                    "legal_consents",
+                    "links",
+                    "legal_country_code"
                 ],
                 "properties": {
-                    "operation": {
-                        "type": "string",
-                        "default": "API_INTEGRATION"
+                    "business_entity": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_business_entity"
                     },
-                    "api_integration_preference": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_referral_partner_config_override": {
-                "required": [
-                    "return_url",
-                    "partner_logo_url"
-                ],
-                "properties": {
-                    "return_url": {
+                    "preferred_language_code": {
                         "type": "string"
                     },
-                    "partner_logo_url": {
+                    "tracking_id": {
+                        "type": "string"
+                    },
+                    "partner_config_override": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_partner_config_override"
+                    },
+                    "operations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_referral_operation"
+                        }
+                    },
+                    "products": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "capabilities": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "legal_consents": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_referral_legal_consent"
+                        }
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    },
+                    "legal_country_code": {
                         "type": "string"
                     }
                 },
@@ -7559,6 +7612,62 @@
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_referral_business_entity_address"
                         }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_business_entity_address": {
+                "required": [
+                    "country_code"
+                ],
+                "properties": {
+                    "country_code": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "default": "WORK"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_legal_consent": {
+                "required": [
+                    "granted"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "default": "SHARE_DATA_CONSENT"
+                    },
+                    "granted": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_operation": {
+                "required": [
+                    "api_integration_preference"
+                ],
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "default": "API_INTEGRATION"
+                    },
+                    "api_integration_preference": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_operation_api_integration_preference": {
+                "required": [
+                    "rest_api_integration"
+                ],
+                "properties": {
+                    "rest_api_integration": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference_rest_api_integration"
                     }
                 },
                 "type": "object"
@@ -7605,175 +7714,67 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_referral_operation_api_integration_preference": {
+            "paypal_v2_referral_partner_config_override": {
                 "required": [
-                    "rest_api_integration"
+                    "return_url",
+                    "partner_logo_url"
                 ],
                 "properties": {
-                    "rest_api_integration": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference_rest_api_integration"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_referral_business_entity_address": {
-                "required": [
-                    "country_code"
-                ],
-                "properties": {
-                    "country_code": {
+                    "return_url": {
                         "type": "string"
                     },
-                    "type": {
-                        "type": "string",
-                        "default": "WORK"
+                    "partner_logo_url": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v2_referral_legal_consent": {
-                "required": [
-                    "granted"
-                ],
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "default": "SHARE_DATA_CONSENT"
-                    },
-                    "granted": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_confirm_order": {
-                "required": [
-                    "payment_source"
-                ],
-                "properties": {
-                    "payment_source": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_customer_channel": {
-                "required": [
-                    "browser_type",
-                    "client_os",
-                    "device_type"
-                ],
-                "properties": {
-                    "browser_type": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "client_os": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "device_type": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_customer": {
-                "required": [
-                    "country_code",
-                    "channel"
-                ],
-                "properties": {
-                    "country_code": {
-                        "description": "ISO 3166-1 alpha-2 country code",
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "channel": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer_channel"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_preferences_payment_source_constraint": {
-                "required": [
-                    "constraint_type",
-                    "payment_sources"
-                ],
-                "properties": {
-                    "constraint_type": {
-                        "type": "string",
-                        "enum": [
-                            "INCLUDE"
-                        ]
-                    },
-                    "payment_sources": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_preferences": {
-                "required": [
-                    "payment_flow",
-                    "commit",
-                    "intent",
-                    "vault",
-                    "payment_source_constraint"
-                ],
-                "properties": {
-                    "payment_flow": {
-                        "type": "string",
-                        "enum": [
-                            "ONE_TIME_PAYMENT"
-                        ]
-                    },
-                    "commit": {
-                        "type": "boolean"
-                    },
-                    "intent": {
-                        "type": "string",
-                        "enum": [
-                            "CAPTURE",
-                            "AUTHORIZE"
-                        ]
-                    },
-                    "vault": {
-                        "type": "boolean"
-                    },
-                    "payment_source_constraint": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences_payment_source_constraint"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_shipping_callback": {
+            "paypal_v3_payment_token": {
                 "required": [
                     "id",
-                    "shipping_address",
-                    "shipping_option",
-                    "purchase_units"
+                    "status",
+                    "customer",
+                    "payment_source",
+                    "links",
+                    "metadata"
                 ],
                 "properties": {
                     "id": {
                         "type": "string"
                     },
-                    "shipping_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    "status": {
+                        "type": "string"
                     },
-                    "shipping_option": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
                     },
-                    "purchase_units": {
+                    "payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
+                    },
+                    "links": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
+                    },
+                    "metadata": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v3_payment_token_metadata"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v3_payment_token_metadata": {
+                "required": [
+                    "order_id"
+                ],
+                "properties": {
+                    "order_id": {
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -268,56 +268,6 @@
     },
     "components": {
         "schemas": {
-            "paypal_v3_payment_token": {
-                "required": [
-                    "id",
-                    "status",
-                    "customer",
-                    "payment_source",
-                    "links",
-                    "metadata"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "customer": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
-                    },
-                    "payment_source": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    },
-                    "metadata": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v3_payment_token_metadata"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v3_payment_token_metadata": {
-                "required": [
-                    "order_id"
-                ],
-                "properties": {
-                    "order_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
             "paypal_error_detail": {
                 "required": [
                     "field",
@@ -445,307 +395,193 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_merchant_integrations": {
-                "required": [
-                    "merchant_id",
-                    "tracking_id",
-                    "products",
-                    "capabilities",
-                    "oauth_integrations",
-                    "granted_permissions",
-                    "payments_receivable",
-                    "legal_name",
-                    "primary_email",
-                    "primary_email_confirmed"
-                ],
-                "properties": {
-                    "merchant_id": {
-                        "type": "string"
-                    },
-                    "tracking_id": {
-                        "type": "string"
-                    },
-                    "products": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_product"
-                        }
-                    },
-                    "capabilities": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_capability"
-                        },
-                        "nullable": true
-                    },
-                    "oauth_integrations": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration"
-                        }
-                    },
-                    "granted_permissions": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "payments_receivable": {
-                        "type": "boolean"
-                    },
-                    "legal_name": {
-                        "type": "string"
-                    },
-                    "primary_email": {
-                        "type": "string"
-                    },
-                    "primary_email_confirmed": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_refund": {
-                "required": [
-                    "amount",
-                    "invoice_number",
-                    "description",
-                    "reason",
-                    "id",
-                    "create_time",
-                    "update_time",
-                    "state",
-                    "refund_from_transaction_fee",
-                    "total_refunded_amount",
-                    "refund_from_received_amount",
-                    "sale_id",
-                    "capture_id",
-                    "parent_payment",
-                    "links"
-                ],
-                "properties": {
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "invoice_number": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "reason": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "refund_from_transaction_fee": {
+            "paypal_v1_capture_transaction_fee": {
+                "allOf": [
+                    {
                         "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "total_refunded_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "refund_from_received_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "sale_id": {
-                        "type": "string"
-                    },
-                    "capture_id": {
-                        "type": "string"
-                    },
-                    "parent_payment": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
                     }
-                },
-                "type": "object"
+                ]
             },
-            "paypal_v1_webhook_list": {
+            "paypal_v1_client_token": {
                 "required": [
-                    "webhooks"
+                    "client_token",
+                    "expires_in",
+                    "expire_date_time"
                 ],
                 "properties": {
-                    "webhooks": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_webhook"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_shipping_tracker": {
-                "required": [
-                    "transaction_id",
-                    "tracking_number",
-                    "status",
-                    "carrier",
-                    "notify_buyer",
-                    "shipment_date"
-                ],
-                "properties": {
-                    "transaction_id": {
+                    "client_token": {
                         "type": "string"
                     },
-                    "tracking_number": {
-                        "type": "string"
+                    "expires_in": {
+                        "description": "The lifetime of the access token, in seconds.",
+                        "type": "integer"
                     },
-                    "status": {
-                        "type": "string"
-                    },
-                    "carrier": {
-                        "type": "string"
-                    },
-                    "notify_buyer": {
-                        "type": "boolean"
-                    },
-                    "shipment_date": {
+                    "expire_date_time": {
+                        "description": "Calculated expiration date",
                         "type": "string",
                         "format": "date-time"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_merchant_tracking": {
+            "paypal_v1_common_address": {
                 "required": [
-                    "merchant_id",
-                    "tracking_id",
-                    "links"
+                    "line_1",
+                    "line_2",
+                    "city",
+                    "country_code",
+                    "postal_code",
+                    "state",
+                    "phone"
                 ],
                 "properties": {
-                    "merchant_id": {
+                    "line_1": {
                         "type": "string"
                     },
-                    "tracking_id": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_billing_cycle": {
-                "required": [
-                    "frequency",
-                    "tenure_type",
-                    "sequence",
-                    "pricing_scheme",
-                    "total_cycles"
-                ],
-                "properties": {
-                    "frequency": {
-                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_frequency"
-                    },
-                    "tenure_type": {
-                        "type": "string"
-                    },
-                    "sequence": {
-                        "type": "integer"
-                    },
-                    "pricing_scheme": {
-                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_pricing_scheme"
-                    },
-                    "total_cycles": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_billing_cycle_frequency": {
-                "required": [
-                    "interval_unit",
-                    "interval_count"
-                ],
-                "properties": {
-                    "interval_unit": {
-                        "type": "string"
-                    },
-                    "interval_count": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_billing_cycle_pricing_scheme": {
-                "required": [
-                    "fixed_price"
-                ],
-                "properties": {
-                    "fixed_price": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_payment_preferences": {
-                "required": [
-                    "auto_bill_outstanding",
-                    "payment_failure_threshold"
-                ],
-                "properties": {
-                    "auto_bill_outstanding": {
-                        "type": "boolean"
-                    },
-                    "payment_failure_threshold": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_plan_taxes": {
-                "required": [
-                    "percentage",
-                    "inclusive"
-                ],
-                "properties": {
-                    "percentage": {
-                        "type": "string"
-                    },
-                    "inclusive": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_webhook": {
-                "required": [
-                    "id",
-                    "url",
-                    "event_types",
-                    "links"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "url": {
+                    "line_2": {
                         "type": "string",
-                        "maxLength": 2048
+                        "nullable": true
                     },
-                    "event_types": {
+                    "city": {
+                        "type": "string"
+                    },
+                    "country_code": {
+                        "type": "string"
+                    },
+                    "postal_code": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "phone": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_amount": {
+                "required": [
+                    "total",
+                    "currency",
+                    "details"
+                ],
+                "properties": {
+                    "total": {
+                        "type": "string"
+                    },
+                    "currency": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "$ref": "#/components/schemas/paypal_v1_common_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_details": {
+                "required": [
+                    "subtotal",
+                    "shipping",
+                    "tax",
+                    "handling_fee",
+                    "shipping_discount",
+                    "discount",
+                    "insurance"
+                ],
+                "properties": {
+                    "subtotal": {
+                        "type": "string"
+                    },
+                    "shipping": {
+                        "type": "string"
+                    },
+                    "tax": {
+                        "type": "string"
+                    },
+                    "handling_fee": {
+                        "type": "string"
+                    },
+                    "shipping_discount": {
+                        "type": "string"
+                    },
+                    "discount": {
+                        "type": "string"
+                    },
+                    "insurance": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_link": {
+                "required": [
+                    "href",
+                    "rel",
+                    "method",
+                    "enc_type"
+                ],
+                "properties": {
+                    "href": {
+                        "type": "string"
+                    },
+                    "rel": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "type": "string"
+                    },
+                    "enc_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_money": {
+                "required": [
+                    "value",
+                    "currency_code"
+                ],
+                "properties": {
+                    "value": {
+                        "type": "string"
+                    },
+                    "currency_code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_common_value": {
+                "required": [
+                    "currency",
+                    "value"
+                ],
+                "properties": {
+                    "currency": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes": {
+                "required": [
+                    "items",
+                    "links"
+                ],
+                "properties": {
+                    "items": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_webhook_event_type"
-                        }
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item"
+                        },
+                        "nullable": true
                     },
                     "links": {
                         "type": "array",
@@ -756,169 +592,7 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_refund_details": {
-                "required": [
-                    "allowed_refund_amount"
-                ],
-                "properties": {
-                    "allowed_refund_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_offer_history": {
-                "required": [
-                    "offer_time",
-                    "actor",
-                    "event_type",
-                    "offer_type"
-                ],
-                "properties": {
-                    "offer_time": {
-                        "type": "string"
-                    },
-                    "actor": {
-                        "type": "string"
-                    },
-                    "event_type": {
-                        "type": "string"
-                    },
-                    "offer_type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions": {
-                "required": [
-                    "merchant_contacted",
-                    "merchant_contacted_outcome",
-                    "merchant_contacted_time",
-                    "merchant_contacted_mode",
-                    "buyer_contacted_time",
-                    "buyer_contacted_channel",
-                    "billing_dispute_properties",
-                    "merchandize_dispute_properties"
-                ],
-                "properties": {
-                    "merchant_contacted": {
-                        "type": "boolean"
-                    },
-                    "merchant_contacted_outcome": {
-                        "type": "string"
-                    },
-                    "merchant_contacted_time": {
-                        "type": "string"
-                    },
-                    "merchant_contacted_mode": {
-                        "type": "string"
-                    },
-                    "buyer_contacted_time": {
-                        "type": "string"
-                    },
-                    "buyer_contacted_channel": {
-                        "type": "string"
-                    },
-                    "billing_dispute_properties": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties"
-                    },
-                    "merchandize_dispute_properties": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_merchandize_dispute_properties"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_communication_details": {
-                "required": [
-                    "email",
-                    "note",
-                    "time_posted"
-                ],
-                "properties": {
-                    "email": {
-                        "type": "string"
-                    },
-                    "note": {
-                        "type": "string"
-                    },
-                    "time_posted": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_dispute_outcome": {
-                "required": [
-                    "outcome_code",
-                    "amount_refunded"
-                ],
-                "properties": {
-                    "outcome_code": {
-                        "type": "string"
-                    },
-                    "amount_refunded": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_evidence_info_tracking_info": {
-                "required": [
-                    "carrier_name",
-                    "carrier_name_other",
-                    "tracking_url",
-                    "tracking_number"
-                ],
-                "properties": {
-                    "carrier_name": {
-                        "type": "string"
-                    },
-                    "carrier_name_other": {
-                        "type": "string"
-                    },
-                    "tracking_url": {
-                        "type": "string"
-                    },
-                    "tracking_number": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_evidence_info_refund_id": {
-                "required": [
-                    "refund_id"
-                ],
-                "properties": {
-                    "refund_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_evidence_info": {
-                "required": [
-                    "tracking_info",
-                    "refund_ids"
-                ],
-                "properties": {
-                    "tracking_info": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_tracking_info"
-                        }
-                    },
-                    "refund_ids": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_refund_id"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_evidence_document": {
+            "paypal_v1_disputes_common_buyer": {
                 "required": [
                     "name"
                 ],
@@ -929,391 +603,208 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_evidence": {
+            "paypal_v1_disputes_common_item": {
                 "required": [
-                    "evidence_type",
-                    "evidence_info",
-                    "documents",
-                    "notes",
-                    "item_id"
+                    "item_id",
+                    "item_description",
+                    "item_quantity",
+                    "partner_transaction_id",
+                    "reason",
+                    "dispute_amount",
+                    "notes"
                 ],
                 "properties": {
-                    "evidence_type": {
-                        "type": "string"
-                    },
-                    "evidence_info": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info"
-                    },
-                    "documents": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_document"
-                        }
-                    },
-                    "notes": {
-                        "type": "string"
-                    },
                     "item_id": {
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_disputed_transaction": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
                     },
-                    {
-                        "required": [
-                            "seller_protection_eligible"
-                        ],
-                        "properties": {
-                            "seller_protection_eligible": {
-                                "type": "boolean"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v1_disputes_item_adjudication": {
-                "required": [
-                    "type",
-                    "adjudication_time",
-                    "reason",
-                    "dispute_life_cycle_stage"
-                ],
-                "properties": {
-                    "type": {
+                    "item_description": {
                         "type": "string"
                     },
-                    "adjudication_time": {
+                    "item_quantity": {
+                        "type": "string"
+                    },
+                    "partner_transaction_id": {
                         "type": "string"
                     },
                     "reason": {
                         "type": "string"
                     },
-                    "dispute_life_cycle_stage": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_message": {
-                "required": [
-                    "posted_by",
-                    "time_posted",
-                    "content"
-                ],
-                "properties": {
-                    "posted_by": {
-                        "type": "string"
-                    },
-                    "time_posted": {
-                        "type": "string"
-                    },
-                    "content": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_dispute_amount": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                ]
-            },
-            "paypal_v1_disputes_item_extensions_merchandize_dispute_properties": {
-                "required": [
-                    "issue_type",
-                    "product_details",
-                    "service_details"
-                ],
-                "properties": {
-                    "issue_type": {
-                        "type": "string"
-                    },
-                    "product_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
-                    },
-                    "service_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount": {
-                "required": [
-                    "correct_transaction_amount",
-                    "correct_transaction_time"
-                ],
-                "properties": {
-                    "correct_transaction_amount": {
+                    "dispute_amount": {
                         "$ref": "#/components/schemas/paypal_v1_common_money"
                     },
-                    "correct_transaction_time": {
+                    "notes": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means": {
+            "paypal_v1_disputes_common_product_details": {
                 "required": [
-                    "charge_different_from_original",
-                    "received_duplicate",
-                    "payment_method",
-                    "payment_instrument_suffix"
+                    "product_received",
+                    "product_received_time",
+                    "sub_reasons",
+                    "purchase_url",
+                    "return_details"
                 ],
                 "properties": {
-                    "charge_different_from_original": {
+                    "product_received": {
+                        "type": "string"
+                    },
+                    "product_received_time": {
+                        "type": "string"
+                    },
+                    "sub_reasons": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
+                        }
+                    },
+                    "purchase_url": {
+                        "type": "string"
+                    },
+                    "return_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_return_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_return_details": {
+                "required": [
+                    "return_time",
+                    "mode",
+                    "receipt",
+                    "return_confirmation_number",
+                    "returned"
+                ],
+                "properties": {
+                    "return_time": {
+                        "type": "string"
+                    },
+                    "mode": {
+                        "type": "string"
+                    },
+                    "receipt": {
                         "type": "boolean"
                     },
-                    "received_duplicate": {
+                    "return_confirmation_number": {
+                        "type": "string"
+                    },
+                    "returned": {
                         "type": "boolean"
-                    },
-                    "payment_method": {
-                        "type": "string"
-                    },
-                    "payment_instrument_suffix": {
-                        "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing": {
+            "paypal_v1_disputes_common_seller": {
                 "required": [
-                    "expected_refund",
-                    "cancellation_details"
+                    "email",
+                    "merchant_id",
+                    "name"
                 ],
                 "properties": {
-                    "expected_refund": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "cancellation_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed": {
-                "required": [
-                    "issue_type",
-                    "expected_refund",
-                    "cancellation_details",
-                    "product_details",
-                    "service_details",
-                    "agreed_refund_details"
-                ],
-                "properties": {
-                    "issue_type": {
+                    "email": {
                         "type": "string"
                     },
-                    "expected_refund": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "cancellation_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
-                    },
-                    "product_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
-                    },
-                    "service_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
-                    },
-                    "agreed_refund_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details": {
-                "required": [
-                    "merchant_agreed_refund",
-                    "merchant_agreed_refund_time"
-                ],
-                "properties": {
-                    "merchant_agreed_refund": {
-                        "type": "boolean"
-                    },
-                    "merchant_agreed_refund_time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details": {
-                "required": [
-                    "cancellation_date",
-                    "cancellation_number",
-                    "cancelled",
-                    "cancellation_mode"
-                ],
-                "properties": {
-                    "cancellation_date": {
-                        "type": "string"
-                    },
-                    "cancellation_number": {
-                        "type": "string"
-                    },
-                    "cancelled": {
-                        "type": "boolean"
-                    },
-                    "cancellation_mode": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction": {
-                "required": [
-                    "received_duplicate",
-                    "original_transaction"
-                ],
-                "properties": {
-                    "received_duplicate": {
-                        "type": "boolean"
-                    },
-                    "original_transaction": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_extensions_billing_dispute_properties": {
-                "required": [
-                    "duplicate_transaction",
-                    "incorrect_transaction_amount",
-                    "payment_by_other_means",
-                    "credit_not_processed",
-                    "canceled_recurring_billing"
-                ],
-                "properties": {
-                    "duplicate_transaction": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction"
-                    },
-                    "incorrect_transaction_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount"
-                    },
-                    "payment_by_other_means": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means"
-                    },
-                    "credit_not_processed": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed"
-                    },
-                    "canceled_recurring_billing": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_partner_action": {
-                "required": [
-                    "id",
-                    "name",
-                    "create_time",
-                    "update_time",
-                    "due_time",
-                    "status",
-                    "amount"
-                ],
-                "properties": {
-                    "id": {
+                    "merchant_id": {
                         "type": "string"
                     },
                     "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_service_details": {
+                "required": [
+                    "description",
+                    "service_started",
+                    "note",
+                    "sub_reasons",
+                    "purchase_url"
+                ],
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "service_started": {
+                        "type": "string"
+                    },
+                    "note": {
+                        "type": "string"
+                    },
+                    "sub_reasons": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
+                        }
+                    },
+                    "purchase_url": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_sub_reason": {
+                "required": [
+                    "sub_reason"
+                ],
+                "properties": {
+                    "sub_reason": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_common_transaction": {
+                "required": [
+                    "buyer_transaction_id",
+                    "seller_transaction_id",
+                    "reference_id",
+                    "create_time",
+                    "transaction_status",
+                    "gross_amount",
+                    "invoice_number",
+                    "custom",
+                    "buyer",
+                    "seller",
+                    "items"
+                ],
+                "properties": {
+                    "buyer_transaction_id": {
+                        "type": "string"
+                    },
+                    "seller_transaction_id": {
+                        "type": "string"
+                    },
+                    "reference_id": {
                         "type": "string"
                     },
                     "create_time": {
                         "type": "string"
                     },
-                    "update_time": {
+                    "transaction_status": {
                         "type": "string"
                     },
-                    "due_time": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_offer": {
-                "required": [
-                    "buyer_requested_amount",
-                    "seller_offered_amount",
-                    "offer_type",
-                    "history"
-                ],
-                "properties": {
-                    "buyer_requested_amount": {
+                    "gross_amount": {
                         "$ref": "#/components/schemas/paypal_v1_common_money"
                     },
-                    "seller_offered_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "offer_type": {
+                    "invoice_number": {
                         "type": "string"
                     },
-                    "history": {
+                    "custom": {
+                        "type": "string"
+                    },
+                    "buyer": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_buyer"
+                    },
+                    "seller": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_seller"
+                    },
+                    "items": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item_offer_history"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_supporting_info": {
-                "required": [
-                    "notes",
-                    "source",
-                    "provided_time"
-                ],
-                "properties": {
-                    "notes": {
-                        "type": "string"
-                    },
-                    "source": {
-                        "type": "string"
-                    },
-                    "provided_time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_item_money_movement": {
-                "required": [
-                    "affected_party",
-                    "amount",
-                    "initiated_time",
-                    "type",
-                    "reason"
-                ],
-                "properties": {
-                    "affected_party": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "initiated_time": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "reason": {
-                        "type": "string"
+                            "$ref": "#/components/schemas/paypal_v1_disputes_common_item"
+                        }
                     }
                 },
                 "type": "object"
@@ -1487,213 +978,120 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_item": {
+            "paypal_v1_disputes_item_adjudication": {
                 "required": [
-                    "item_id",
-                    "item_description",
-                    "item_quantity",
-                    "partner_transaction_id",
+                    "type",
+                    "adjudication_time",
                     "reason",
-                    "dispute_amount",
-                    "notes"
+                    "dispute_life_cycle_stage"
                 ],
                 "properties": {
-                    "item_id": {
+                    "type": {
                         "type": "string"
                     },
-                    "item_description": {
-                        "type": "string"
-                    },
-                    "item_quantity": {
-                        "type": "string"
-                    },
-                    "partner_transaction_id": {
+                    "adjudication_time": {
                         "type": "string"
                     },
                     "reason": {
                         "type": "string"
                     },
-                    "dispute_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "notes": {
+                    "dispute_life_cycle_stage": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_transaction": {
-                "required": [
-                    "buyer_transaction_id",
-                    "seller_transaction_id",
-                    "reference_id",
-                    "create_time",
-                    "transaction_status",
-                    "gross_amount",
-                    "invoice_number",
-                    "custom",
-                    "buyer",
-                    "seller",
-                    "items"
-                ],
-                "properties": {
-                    "buyer_transaction_id": {
-                        "type": "string"
-                    },
-                    "seller_transaction_id": {
-                        "type": "string"
-                    },
-                    "reference_id": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "transaction_status": {
-                        "type": "string"
-                    },
-                    "gross_amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "invoice_number": {
-                        "type": "string"
-                    },
-                    "custom": {
-                        "type": "string"
-                    },
-                    "buyer": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_buyer"
-                    },
-                    "seller": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_seller"
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_common_item"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_product_details": {
-                "required": [
-                    "product_received",
-                    "product_received_time",
-                    "sub_reasons",
-                    "purchase_url",
-                    "return_details"
-                ],
-                "properties": {
-                    "product_received": {
-                        "type": "string"
-                    },
-                    "product_received_time": {
-                        "type": "string"
-                    },
-                    "sub_reasons": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
-                        }
-                    },
-                    "purchase_url": {
-                        "type": "string"
-                    },
-                    "return_details": {
-                        "$ref": "#/components/schemas/paypal_v1_disputes_common_return_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_seller": {
+            "paypal_v1_disputes_item_communication_details": {
                 "required": [
                     "email",
-                    "merchant_id",
-                    "name"
+                    "note",
+                    "time_posted"
                 ],
                 "properties": {
                     "email": {
                         "type": "string"
                     },
-                    "merchant_id": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_sub_reason": {
-                "required": [
-                    "sub_reason"
-                ],
-                "properties": {
-                    "sub_reason": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_disputes_common_service_details": {
-                "required": [
-                    "description",
-                    "service_started",
-                    "note",
-                    "sub_reasons",
-                    "purchase_url"
-                ],
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "service_started": {
-                        "type": "string"
-                    },
                     "note": {
                         "type": "string"
                     },
-                    "sub_reasons": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_common_sub_reason"
-                        }
-                    },
-                    "purchase_url": {
+                    "time_posted": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_return_details": {
+            "paypal_v1_disputes_item_dispute_amount": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    }
+                ]
+            },
+            "paypal_v1_disputes_item_dispute_outcome": {
                 "required": [
-                    "return_time",
-                    "mode",
-                    "receipt",
-                    "return_confirmation_number",
-                    "returned"
+                    "outcome_code",
+                    "amount_refunded"
                 ],
                 "properties": {
-                    "return_time": {
+                    "outcome_code": {
                         "type": "string"
                     },
-                    "mode": {
-                        "type": "string"
-                    },
-                    "receipt": {
-                        "type": "boolean"
-                    },
-                    "return_confirmation_number": {
-                        "type": "string"
-                    },
-                    "returned": {
-                        "type": "boolean"
+                    "amount_refunded": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes_common_buyer": {
+            "paypal_v1_disputes_item_disputed_transaction": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
+                    },
+                    {
+                        "required": [
+                            "seller_protection_eligible"
+                        ],
+                        "properties": {
+                            "seller_protection_eligible": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v1_disputes_item_evidence": {
+                "required": [
+                    "evidence_type",
+                    "evidence_info",
+                    "documents",
+                    "notes",
+                    "item_id"
+                ],
+                "properties": {
+                    "evidence_type": {
+                        "type": "string"
+                    },
+                    "evidence_info": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info"
+                    },
+                    "documents": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_document"
+                        }
+                    },
+                    "notes": {
+                        "type": "string"
+                    },
+                    "item_id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_evidence_document": {
                 "required": [
                     "name"
                 ],
@@ -1704,242 +1102,440 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_webhook_event_type": {
+            "paypal_v1_disputes_item_evidence_evidence_info": {
                 "required": [
-                    "name",
-                    "description",
-                    "status",
-                    "resource_version"
+                    "tracking_info",
+                    "refund_ids"
                 ],
                 "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "resource_version": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_webhook_event": {
-                "required": [
-                    "id",
-                    "resource_type",
-                    "event_type",
-                    "summary",
-                    "resource",
-                    "create_time",
-                    "links",
-                    "event_version",
-                    "resource_version"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "resource_type": {
-                        "type": "string"
-                    },
-                    "event_type": {
-                        "type": "string"
-                    },
-                    "summary": {
-                        "type": "string"
-                    },
-                    "resource": {
-                        "nullable": true,
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v3_payment_token"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_webhook_resource"
-                            },
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription"
-                            }
-                        ]
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "links": {
+                    "tracking_info": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_tracking_info"
                         }
                     },
-                    "event_version": {
-                        "type": "string"
-                    },
-                    "resource_version": {
+                    "refund_ids": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_evidence_evidence_info_refund_id"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_evidence_evidence_info_refund_id": {
+                "required": [
+                    "refund_id"
+                ],
+                "properties": {
+                    "refund_id": {
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_webhook_resource": {
+            "paypal_v1_disputes_item_evidence_evidence_info_tracking_info": {
                 "required": [
-                    "id",
-                    "parent_payment",
-                    "billing_agreement_id",
-                    "sale_id",
-                    "refund_reason_code",
-                    "update_time",
-                    "amount",
-                    "payment_mode",
-                    "create_time",
-                    "clearing_time",
-                    "protection_eligibility_type",
-                    "protection_eligibility",
-                    "transaction_fee",
-                    "invoice_number",
-                    "links",
-                    "state",
-                    "merchant_id"
+                    "carrier_name",
+                    "carrier_name_other",
+                    "tracking_url",
+                    "tracking_number"
                 ],
                 "properties": {
-                    "id": {
+                    "carrier_name": {
                         "type": "string"
                     },
-                    "parent_payment": {
-                        "type": "string",
-                        "nullable": true
+                    "carrier_name_other": {
+                        "type": "string"
                     },
-                    "billing_agreement_id": {
-                        "type": "string",
-                        "nullable": true
+                    "tracking_url": {
+                        "type": "string"
                     },
-                    "sale_id": {
-                        "type": "string",
-                        "nullable": true
+                    "tracking_number": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions": {
+                "required": [
+                    "merchant_contacted",
+                    "merchant_contacted_outcome",
+                    "merchant_contacted_time",
+                    "merchant_contacted_mode",
+                    "buyer_contacted_time",
+                    "buyer_contacted_channel",
+                    "billing_dispute_properties",
+                    "merchandize_dispute_properties"
+                ],
+                "properties": {
+                    "merchant_contacted": {
+                        "type": "boolean"
                     },
-                    "refund_reason_code": {
-                        "type": "string",
-                        "nullable": true
+                    "merchant_contacted_outcome": {
+                        "type": "string"
                     },
-                    "update_time": {
+                    "merchant_contacted_time": {
+                        "type": "string"
+                    },
+                    "merchant_contacted_mode": {
+                        "type": "string"
+                    },
+                    "buyer_contacted_time": {
+                        "type": "string"
+                    },
+                    "buyer_contacted_channel": {
+                        "type": "string"
+                    },
+                    "billing_dispute_properties": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties"
+                    },
+                    "merchandize_dispute_properties": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_merchandize_dispute_properties"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties": {
+                "required": [
+                    "duplicate_transaction",
+                    "incorrect_transaction_amount",
+                    "payment_by_other_means",
+                    "credit_not_processed",
+                    "canceled_recurring_billing"
+                ],
+                "properties": {
+                    "duplicate_transaction": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction"
+                    },
+                    "incorrect_transaction_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount"
+                    },
+                    "payment_by_other_means": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means"
+                    },
+                    "credit_not_processed": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed"
+                    },
+                    "canceled_recurring_billing": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing": {
+                "required": [
+                    "expected_refund",
+                    "cancellation_details"
+                ],
+                "properties": {
+                    "expected_refund": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "cancellation_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details": {
+                "required": [
+                    "merchant_agreed_refund",
+                    "merchant_agreed_refund_time"
+                ],
+                "properties": {
+                    "merchant_agreed_refund": {
+                        "type": "boolean"
+                    },
+                    "merchant_agreed_refund_time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details": {
+                "required": [
+                    "cancellation_date",
+                    "cancellation_number",
+                    "cancelled",
+                    "cancellation_mode"
+                ],
+                "properties": {
+                    "cancellation_date": {
+                        "type": "string"
+                    },
+                    "cancellation_number": {
+                        "type": "string"
+                    },
+                    "cancelled": {
+                        "type": "boolean"
+                    },
+                    "cancellation_mode": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed": {
+                "required": [
+                    "issue_type",
+                    "expected_refund",
+                    "cancellation_details",
+                    "product_details",
+                    "service_details",
+                    "agreed_refund_details"
+                ],
+                "properties": {
+                    "issue_type": {
+                        "type": "string"
+                    },
+                    "expected_refund": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "cancellation_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"
+                    },
+                    "product_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
+                    },
+                    "service_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
+                    },
+                    "agreed_refund_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction": {
+                "required": [
+                    "received_duplicate",
+                    "original_transaction"
+                ],
+                "properties": {
+                    "received_duplicate": {
+                        "type": "boolean"
+                    },
+                    "original_transaction": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_transaction"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount": {
+                "required": [
+                    "correct_transaction_amount",
+                    "correct_transaction_time"
+                ],
+                "properties": {
+                    "correct_transaction_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "correct_transaction_time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means": {
+                "required": [
+                    "charge_different_from_original",
+                    "received_duplicate",
+                    "payment_method",
+                    "payment_instrument_suffix"
+                ],
+                "properties": {
+                    "charge_different_from_original": {
+                        "type": "boolean"
+                    },
+                    "received_duplicate": {
+                        "type": "boolean"
+                    },
+                    "payment_method": {
+                        "type": "string"
+                    },
+                    "payment_instrument_suffix": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_extensions_merchandize_dispute_properties": {
+                "required": [
+                    "issue_type",
+                    "product_details",
+                    "service_details"
+                ],
+                "properties": {
+                    "issue_type": {
+                        "type": "string"
+                    },
+                    "product_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_product_details"
+                    },
+                    "service_details": {
+                        "$ref": "#/components/schemas/paypal_v1_disputes_common_service_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_message": {
+                "required": [
+                    "posted_by",
+                    "time_posted",
+                    "content"
+                ],
+                "properties": {
+                    "posted_by": {
+                        "type": "string"
+                    },
+                    "time_posted": {
+                        "type": "string"
+                    },
+                    "content": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_money_movement": {
+                "required": [
+                    "affected_party",
+                    "amount",
+                    "initiated_time",
+                    "type",
+                    "reason"
+                ],
+                "properties": {
+                    "affected_party": {
                         "type": "string"
                     },
                     "amount": {
                         "$ref": "#/components/schemas/paypal_v1_common_amount"
                     },
-                    "payment_mode": {
+                    "initiated_time": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_offer": {
+                "required": [
+                    "buyer_requested_amount",
+                    "seller_offered_amount",
+                    "offer_type",
+                    "history"
+                ],
+                "properties": {
+                    "buyer_requested_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "seller_offered_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "offer_type": {
+                        "type": "string"
+                    },
+                    "history": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_disputes_item_offer_history"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_offer_history": {
+                "required": [
+                    "offer_time",
+                    "actor",
+                    "event_type",
+                    "offer_type"
+                ],
+                "properties": {
+                    "offer_time": {
+                        "type": "string"
+                    },
+                    "actor": {
+                        "type": "string"
+                    },
+                    "event_type": {
+                        "type": "string"
+                    },
+                    "offer_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_disputes_item_partner_action": {
+                "required": [
+                    "id",
+                    "name",
+                    "create_time",
+                    "update_time",
+                    "due_time",
+                    "status",
+                    "amount"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
                         "type": "string"
                     },
                     "create_time": {
                         "type": "string"
                     },
-                    "clearing_time": {
+                    "update_time": {
                         "type": "string"
                     },
-                    "protection_eligibility_type": {
+                    "due_time": {
                         "type": "string"
                     },
-                    "protection_eligibility": {
+                    "status": {
                         "type": "string"
                     },
-                    "transaction_fee": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "invoice_number": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "merchant_id": {
-                        "type": "string",
-                        "nullable": true
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_token": {
+            "paypal_v1_disputes_item_refund_details": {
                 "required": [
-                    "scope",
-                    "nonce",
-                    "access_token",
-                    "token_type",
-                    "app_id",
-                    "id_token",
-                    "expires_in",
-                    "expire_date_time"
+                    "allowed_refund_amount"
                 ],
                 "properties": {
-                    "scope": {
-                        "description": "Scopes expressed in the form of resource URL endpoints. The value of the scope parameter\nis expressed as a list of space-delimited, case-sensitive strings.",
-                        "type": "string"
-                    },
-                    "nonce": {
-                        "type": "string"
-                    },
-                    "access_token": {
-                        "description": "The access token issued by PayPal. After the access token\nexpires (see $expiresIn), you must request a new access token.",
-                        "type": "string"
-                    },
-                    "token_type": {
-                        "description": "The type of the token issued as described in OAuth2.0 RFC6749,\nSection 7.1. Value is case insensitive.",
-                        "type": "string"
-                    },
-                    "app_id": {
-                        "type": "string"
-                    },
-                    "id_token": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "expires_in": {
-                        "description": "The lifetime of the access token, in seconds.",
-                        "type": "integer"
-                    },
-                    "expire_date_time": {
-                        "description": "Calculated expiration date",
-                        "type": "string",
-                        "format": "date-time"
+                    "allowed_refund_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_client_token": {
+            "paypal_v1_disputes_item_supporting_info": {
                 "required": [
-                    "client_token",
-                    "expires_in",
-                    "expire_date_time"
+                    "notes",
+                    "source",
+                    "provided_time"
                 ],
                 "properties": {
-                    "client_token": {
+                    "notes": {
                         "type": "string"
                     },
-                    "expires_in": {
-                        "description": "The lifetime of the access token, in seconds.",
-                        "type": "integer"
+                    "source": {
+                        "type": "string"
                     },
-                    "expire_date_time": {
-                        "description": "Calculated expiration date",
-                        "type": "string",
-                        "format": "date-time"
+                    "provided_time": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -1982,148 +1578,295 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_common_value": {
+            "paypal_v1_merchant_integrations": {
                 "required": [
-                    "currency",
+                    "merchant_id",
+                    "tracking_id",
+                    "products",
+                    "capabilities",
+                    "oauth_integrations",
+                    "granted_permissions",
+                    "payments_receivable",
+                    "legal_name",
+                    "primary_email",
+                    "primary_email_confirmed"
+                ],
+                "properties": {
+                    "merchant_id": {
+                        "type": "string"
+                    },
+                    "tracking_id": {
+                        "type": "string"
+                    },
+                    "products": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_product"
+                        }
+                    },
+                    "capabilities": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_capability"
+                        },
+                        "nullable": true
+                    },
+                    "oauth_integrations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration"
+                        }
+                    },
+                    "granted_permissions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "payments_receivable": {
+                        "type": "boolean"
+                    },
+                    "legal_name": {
+                        "type": "string"
+                    },
+                    "primary_email": {
+                        "type": "string"
+                    },
+                    "primary_email_confirmed": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_capability": {
+                "required": [
+                    "name",
+                    "status"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_credentials": {
+                "required": [
+                    "client_id",
+                    "client_secret",
+                    "payer_id"
+                ],
+                "properties": {
+                    "client_id": {
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "type": "string"
+                    },
+                    "payer_id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_oauth_integration": {
+                "required": [
+                    "integrationMethod",
+                    "integrationType",
+                    "oauthThirdParty"
+                ],
+                "properties": {
+                    "integration_method": {
+                        "type": "string"
+                    },
+                    "integration_type": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "oauth_third_party": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration_oauth_third_party"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_oauth_integration_oauth_third_party": {
+                "required": [
+                    "merchantClientId",
+                    "partnerClientId",
+                    "scopes"
+                ],
+                "properties": {
+                    "access_token": {
+                        "type": "string"
+                    },
+                    "merchant_client_id": {
+                        "type": "string"
+                    },
+                    "partner_client_id": {
+                        "type": "string"
+                    },
+                    "refresh_token": {
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_integrations_product": {
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "vetting_status": {
+                        "type": "string"
+                    },
+                    "capabilities": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_merchant_tracking": {
+                "required": [
+                    "merchant_id",
+                    "tracking_id",
+                    "links"
+                ],
+                "properties": {
+                    "merchant_id": {
+                        "type": "string"
+                    },
+                    "tracking_id": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_patch": {
+                "required": [
+                    "op",
+                    "path",
                     "value"
                 ],
                 "properties": {
-                    "currency": {
+                    "op": {
+                        "type": "string",
+                        "enum": [
+                            "add",
+                            "replace"
+                        ]
+                    },
+                    "path": {
                         "type": "string"
                     },
                     "value": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        ]
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_common_link": {
+            "paypal_v1_payment": {
                 "required": [
-                    "href",
-                    "rel",
-                    "method",
-                    "enc_type"
-                ],
-                "properties": {
-                    "href": {
-                        "type": "string"
-                    },
-                    "rel": {
-                        "type": "string"
-                    },
-                    "method": {
-                        "type": "string"
-                    },
-                    "enc_type": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_details": {
-                "required": [
-                    "subtotal",
-                    "shipping",
-                    "tax",
-                    "handling_fee",
-                    "shipping_discount",
-                    "discount",
-                    "insurance"
-                ],
-                "properties": {
-                    "subtotal": {
-                        "type": "string"
-                    },
-                    "shipping": {
-                        "type": "string"
-                    },
-                    "tax": {
-                        "type": "string"
-                    },
-                    "handling_fee": {
-                        "type": "string"
-                    },
-                    "shipping_discount": {
-                        "type": "string"
-                    },
-                    "discount": {
-                        "type": "string"
-                    },
-                    "insurance": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_amount": {
-                "required": [
-                    "total",
-                    "currency",
-                    "details"
-                ],
-                "properties": {
-                    "total": {
-                        "type": "string"
-                    },
-                    "currency": {
-                        "type": "string"
-                    },
-                    "details": {
-                        "$ref": "#/components/schemas/paypal_v1_common_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_address": {
-                "required": [
-                    "line_1",
-                    "line_2",
-                    "city",
-                    "country_code",
-                    "postal_code",
+                    "id",
                     "state",
-                    "phone"
+                    "cart",
+                    "payer",
+                    "transactions",
+                    "create_time",
+                    "update_time",
+                    "links",
+                    "redirect_urls",
+                    "application_context",
+                    "payment_instruction"
                 ],
                 "properties": {
-                    "line_1": {
+                    "id": {
                         "type": "string"
                     },
-                    "line_2": {
+                    "intent": {
                         "type": "string",
-                        "nullable": true
-                    },
-                    "city": {
-                        "type": "string"
-                    },
-                    "country_code": {
-                        "type": "string"
-                    },
-                    "postal_code": {
-                        "type": "string"
+                        "default": "sale",
+                        "enum": [
+                            "sale",
+                            "authorize",
+                            "order"
+                        ]
                     },
                     "state": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "phone": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_common_money": {
-                "required": [
-                    "value",
-                    "currency_code"
-                ],
-                "properties": {
-                    "value": {
                         "type": "string"
                     },
-                    "currency_code": {
+                    "cart": {
                         "type": "string"
+                    },
+                    "payer": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payer"
+                    },
+                    "transactions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_payment_transaction"
+                        }
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "redirect_urls": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_redirect_urls"
+                    },
+                    "application_context": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_application_context"
+                    },
+                    "payment_instruction": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction"
+                            }
+                        ],
+                        "nullable": true
                     }
                 },
                 "type": "object"
@@ -2155,6 +1898,160 @@
                     "user_action": {
                         "type": "string",
                         "default": "commit"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payer": {
+                "required": [
+                    "payment_method",
+                    "status",
+                    "payer_info",
+                    "external_selected_funding_instrument_type"
+                ],
+                "properties": {
+                    "payment_method": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "payer_info": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payer_payer_info"
+                    },
+                    "external_selected_funding_instrument_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payer_execute_payer_info": {
+                "required": [
+                    "payer_id"
+                ],
+                "properties": {
+                    "payer_id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payer_payer_info": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payer_execute_payer_info"
+                    },
+                    {
+                        "required": [
+                            "email",
+                            "first_name",
+                            "last_name",
+                            "billing_address",
+                            "shipping_address",
+                            "phone",
+                            "country_code"
+                        ],
+                        "properties": {
+                            "email": {
+                                "type": "string"
+                            },
+                            "first_name": {
+                                "type": "string"
+                            },
+                            "last_name": {
+                                "type": "string"
+                            },
+                            "billing_address": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/paypal_v1_common_address"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "shipping_address": {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
+                            },
+                            "phone": {
+                                "type": "string"
+                            },
+                            "country_code": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v1_payment_payment_instruction": {
+                "required": [
+                    "reference_number",
+                    "recipient_banking_instruction",
+                    "amount",
+                    "payment_due_date",
+                    "instruction_type",
+                    "links"
+                ],
+                "properties": {
+                    "reference_number": {
+                        "type": "string"
+                    },
+                    "recipient_banking_instruction": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction_recipient_banking_instruction"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "payment_due_date": {
+                        "type": "string"
+                    },
+                    "instruction_type": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_payment_instruction_recipient_banking_instruction": {
+                "required": [
+                    "bank_name",
+                    "account_holder_name",
+                    "international_bank_account_number",
+                    "bank_identifier_code"
+                ],
+                "properties": {
+                    "bank_name": {
+                        "type": "string"
+                    },
+                    "account_holder_name": {
+                        "type": "string"
+                    },
+                    "international_bank_account_number": {
+                        "type": "string"
+                    },
+                    "bank_identifier_code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_redirect_urls": {
+                "required": [
+                    "return_url",
+                    "cancel_url"
+                ],
+                "properties": {
+                    "return_url": {
+                        "type": "string"
+                    },
+                    "cancel_url": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -2207,38 +2104,90 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_payment_payment_instruction": {
+            "paypal_v1_payment_transaction_item_list": {
                 "required": [
-                    "reference_number",
-                    "recipient_banking_instruction",
-                    "amount",
-                    "payment_due_date",
-                    "instruction_type",
-                    "links"
+                    "shipping_address",
+                    "items",
+                    "shipping_options",
+                    "shipping_phone_number"
                 ],
                 "properties": {
-                    "reference_number": {
-                        "type": "string"
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
                     },
-                    "recipient_banking_instruction": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction_recipient_banking_instruction"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
-                    },
-                    "payment_due_date": {
-                        "type": "string"
-                    },
-                    "instruction_type": {
-                        "type": "string"
-                    },
-                    "links": {
+                    "items": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_item"
                         }
+                    },
+                    "shipping_options": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_option"
+                        }
+                    },
+                    "shipping_phone_number": {
+                        "type": "string"
                     }
                 },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_item_list_item": {
+                "required": [
+                    "name",
+                    "currency",
+                    "price",
+                    "quantity",
+                    "sku",
+                    "tax"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 127
+                    },
+                    "currency": {
+                        "type": "string"
+                    },
+                    "price": {
+                        "type": "string"
+                    },
+                    "quantity": {
+                        "type": "integer"
+                    },
+                    "sku": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 127
+                    },
+                    "tax": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_item_list_shipping_address": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v1_common_address"
+                    },
+                    {
+                        "required": [
+                            "recipient_name"
+                        ],
+                        "properties": {
+                            "recipient_name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v1_payment_transaction_item_list_shipping_option": {
+                "properties": {},
                 "type": "object"
             },
             "paypal_v1_payment_transaction_payee": {
@@ -2251,6 +2200,120 @@
                         "type": "string"
                     },
                     "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_related_resource": {
+                "required": [
+                    "sale",
+                    "authorization",
+                    "order",
+                    "refund",
+                    "capture"
+                ],
+                "properties": {
+                    "sale": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_sale"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "authorization": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_authorization"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "order": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_order"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "refund": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_refund"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "capture": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_capture"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_related_resource_authorization": {
+                "required": [
+                    "id",
+                    "state",
+                    "amount",
+                    "payment_mode",
+                    "create_time",
+                    "update_time",
+                    "protection_eligibility",
+                    "protection_eligibility_type",
+                    "receipt_id",
+                    "parent_payment",
+                    "links",
+                    "reason_code",
+                    "valid_until"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "payment_mode": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "protection_eligibility": {
+                        "type": "string"
+                    },
+                    "protection_eligibility_type": {
+                        "type": "string"
+                    },
+                    "receipt_id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "reason_code": {
+                        "type": "string"
+                    },
+                    "valid_until": {
                         "type": "string"
                     }
                 },
@@ -2317,6 +2380,64 @@
                         "$ref": "#/components/schemas/paypal_v1_common_value"
                     },
                     "invoice_number": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_payment_transaction_related_resource_order": {
+                "required": [
+                    "id",
+                    "state",
+                    "amount",
+                    "payment_mode",
+                    "create_time",
+                    "update_time",
+                    "protection_eligibility",
+                    "protection_eligibility_type",
+                    "receipt_id",
+                    "parent_payment",
+                    "links",
+                    "reason_code"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "payment_mode": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "protection_eligibility": {
+                        "type": "string"
+                    },
+                    "protection_eligibility_type": {
+                        "type": "string"
+                    },
+                    "receipt_id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "reason_code": {
                         "type": "string"
                     }
                 },
@@ -2442,662 +2563,6 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_payment_transaction_related_resource_order": {
-                "required": [
-                    "id",
-                    "state",
-                    "amount",
-                    "payment_mode",
-                    "create_time",
-                    "update_time",
-                    "protection_eligibility",
-                    "protection_eligibility_type",
-                    "receipt_id",
-                    "parent_payment",
-                    "links",
-                    "reason_code"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "payment_mode": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "protection_eligibility": {
-                        "type": "string"
-                    },
-                    "protection_eligibility_type": {
-                        "type": "string"
-                    },
-                    "receipt_id": {
-                        "type": "string"
-                    },
-                    "parent_payment": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "reason_code": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_related_resource_authorization": {
-                "required": [
-                    "id",
-                    "state",
-                    "amount",
-                    "payment_mode",
-                    "create_time",
-                    "update_time",
-                    "protection_eligibility",
-                    "protection_eligibility_type",
-                    "receipt_id",
-                    "parent_payment",
-                    "links",
-                    "reason_code",
-                    "valid_until"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_amount"
-                    },
-                    "payment_mode": {
-                        "type": "string"
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "protection_eligibility": {
-                        "type": "string"
-                    },
-                    "protection_eligibility_type": {
-                        "type": "string"
-                    },
-                    "receipt_id": {
-                        "type": "string"
-                    },
-                    "parent_payment": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "reason_code": {
-                        "type": "string"
-                    },
-                    "valid_until": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list": {
-                "required": [
-                    "shipping_address",
-                    "items",
-                    "shipping_options",
-                    "shipping_phone_number"
-                ],
-                "properties": {
-                    "shipping_address": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_item"
-                        }
-                    },
-                    "shipping_options": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_option"
-                        }
-                    },
-                    "shipping_phone_number": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list_item": {
-                "required": [
-                    "name",
-                    "currency",
-                    "price",
-                    "quantity",
-                    "sku",
-                    "tax"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 127
-                    },
-                    "currency": {
-                        "type": "string"
-                    },
-                    "price": {
-                        "type": "string"
-                    },
-                    "quantity": {
-                        "type": "integer"
-                    },
-                    "sku": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 127
-                    },
-                    "tax": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list_shipping_option": {
-                "properties": {},
-                "type": "object"
-            },
-            "paypal_v1_payment_transaction_item_list_shipping_address": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_common_address"
-                    },
-                    {
-                        "required": [
-                            "recipient_name"
-                        ],
-                        "properties": {
-                            "recipient_name": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v1_payment_transaction_related_resource": {
-                "required": [
-                    "sale",
-                    "authorization",
-                    "order",
-                    "refund",
-                    "capture"
-                ],
-                "properties": {
-                    "sale": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_sale"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "authorization": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_authorization"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "order": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_order"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "refund": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_refund"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "capture": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_related_resource_capture"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payer_execute_payer_info": {
-                "required": [
-                    "payer_id"
-                ],
-                "properties": {
-                    "payer_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payer_payer_info": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payer_execute_payer_info"
-                    },
-                    {
-                        "required": [
-                            "email",
-                            "first_name",
-                            "last_name",
-                            "billing_address",
-                            "shipping_address",
-                            "phone",
-                            "country_code"
-                        ],
-                        "properties": {
-                            "email": {
-                                "type": "string"
-                            },
-                            "first_name": {
-                                "type": "string"
-                            },
-                            "last_name": {
-                                "type": "string"
-                            },
-                            "billing_address": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/paypal_v1_common_address"
-                                    }
-                                ],
-                                "nullable": true
-                            },
-                            "shipping_address": {
-                                "$ref": "#/components/schemas/paypal_v1_payment_transaction_item_list_shipping_address"
-                            },
-                            "phone": {
-                                "type": "string"
-                            },
-                            "country_code": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v1_payment_redirect_urls": {
-                "required": [
-                    "return_url",
-                    "cancel_url"
-                ],
-                "properties": {
-                    "return_url": {
-                        "type": "string"
-                    },
-                    "cancel_url": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payer": {
-                "required": [
-                    "payment_method",
-                    "status",
-                    "payer_info",
-                    "external_selected_funding_instrument_type"
-                ],
-                "properties": {
-                    "payment_method": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "payer_info": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payer_payer_info"
-                    },
-                    "external_selected_funding_instrument_type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment_payment_instruction_recipient_banking_instruction": {
-                "required": [
-                    "bank_name",
-                    "account_holder_name",
-                    "international_bank_account_number",
-                    "bank_identifier_code"
-                ],
-                "properties": {
-                    "bank_name": {
-                        "type": "string"
-                    },
-                    "account_holder_name": {
-                        "type": "string"
-                    },
-                    "international_bank_account_number": {
-                        "type": "string"
-                    },
-                    "bank_identifier_code": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_patch": {
-                "required": [
-                    "op",
-                    "path",
-                    "value"
-                ],
-                "properties": {
-                    "op": {
-                        "type": "string",
-                        "enum": [
-                            "add",
-                            "replace"
-                        ]
-                    },
-                    "path": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "mixed"
-                                }
-                            }
-                        ]
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_product": {
-                "required": [
-                    "name",
-                    "description",
-                    "type"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_application_context": {
-                "required": [
-                    "brand_name",
-                    "locale",
-                    "return_url",
-                    "cancel_url"
-                ],
-                "properties": {
-                    "user_action": {
-                        "type": "string",
-                        "default": "SUBSCRIBE_NOW"
-                    },
-                    "brand_name": {
-                        "type": "string"
-                    },
-                    "locale": {
-                        "type": "string"
-                    },
-                    "shipping_preference": {
-                        "type": "string",
-                        "default": "SET_PROVIDED_ADDRESS"
-                    },
-                    "return_url": {
-                        "type": "string"
-                    },
-                    "cancel_url": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_billing_info_cycle_execution": {
-                "required": [
-                    "tenure_type",
-                    "sequence",
-                    "cycles_completed",
-                    "cycles_remaining",
-                    "total_cycles"
-                ],
-                "properties": {
-                    "tenure_type": {
-                        "type": "string"
-                    },
-                    "sequence": {
-                        "type": "integer"
-                    },
-                    "cycles_completed": {
-                        "type": "integer"
-                    },
-                    "cycles_remaining": {
-                        "type": "integer"
-                    },
-                    "total_cycles": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_billing_info_outstanding_balance": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    }
-                ]
-            },
-            "paypal_v1_subscription_billing_info_last_payment": {
-                "required": [
-                    "amount",
-                    "time"
-                ],
-                "properties": {
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v1_common_money"
-                    },
-                    "time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_billing_info": {
-                "required": [
-                    "outstanding_balance",
-                    "cycle_executions",
-                    "last_payment",
-                    "next_billing_time",
-                    "failed_payments_count"
-                ],
-                "properties": {
-                    "outstanding_balance": {
-                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_outstanding_balance"
-                    },
-                    "cycle_executions": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_cycle_execution"
-                        }
-                    },
-                    "last_payment": {
-                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_last_payment"
-                    },
-                    "next_billing_time": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "failed_payments_count": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_name": {
-                "required": [
-                    "given_name",
-                    "surname"
-                ],
-                "properties": {
-                    "given_name": {
-                        "type": "string"
-                    },
-                    "surname": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_shipping_address_name": {
-                "required": [
-                    "full_name"
-                ],
-                "properties": {
-                    "full_name": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_shipping_address_address": {
-                "required": [
-                    "address_line_1",
-                    "address_line_2",
-                    "admin_area_1",
-                    "admin_area_2",
-                    "postal_code",
-                    "country_code"
-                ],
-                "properties": {
-                    "address_line_1": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "address_line_2": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "admin_area_1": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "admin_area_2": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "postal_code": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "country_code": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber_shipping_address": {
-                "required": [
-                    "name",
-                    "address"
-                ],
-                "properties": {
-                    "name": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_name"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "address": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_address"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_subscription_subscriber": {
-                "required": [
-                    "name",
-                    "email_address",
-                    "payer_id",
-                    "shipping_address"
-                ],
-                "properties": {
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_name"
-                    },
-                    "email_address": {
-                        "type": "string"
-                    },
-                    "payer_id": {
-                        "type": "string"
-                    },
-                    "shipping_address": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
             "paypal_v1_plan": {
                 "required": [
                     "product_id",
@@ -3137,6 +2602,178 @@
                 },
                 "type": "object"
             },
+            "paypal_v1_plan_billing_cycle": {
+                "required": [
+                    "frequency",
+                    "tenure_type",
+                    "sequence",
+                    "pricing_scheme",
+                    "total_cycles"
+                ],
+                "properties": {
+                    "frequency": {
+                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_frequency"
+                    },
+                    "tenure_type": {
+                        "type": "string"
+                    },
+                    "sequence": {
+                        "type": "integer"
+                    },
+                    "pricing_scheme": {
+                        "$ref": "#/components/schemas/paypal_v1_plan_billing_cycle_pricing_scheme"
+                    },
+                    "total_cycles": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_billing_cycle_frequency": {
+                "required": [
+                    "interval_unit",
+                    "interval_count"
+                ],
+                "properties": {
+                    "interval_unit": {
+                        "type": "string"
+                    },
+                    "interval_count": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_billing_cycle_pricing_scheme": {
+                "required": [
+                    "fixed_price"
+                ],
+                "properties": {
+                    "fixed_price": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_payment_preferences": {
+                "required": [
+                    "auto_bill_outstanding",
+                    "payment_failure_threshold"
+                ],
+                "properties": {
+                    "auto_bill_outstanding": {
+                        "type": "boolean"
+                    },
+                    "payment_failure_threshold": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_plan_taxes": {
+                "required": [
+                    "percentage",
+                    "inclusive"
+                ],
+                "properties": {
+                    "percentage": {
+                        "type": "string"
+                    },
+                    "inclusive": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_product": {
+                "required": [
+                    "name",
+                    "description",
+                    "type"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_refund": {
+                "required": [
+                    "amount",
+                    "invoice_number",
+                    "description",
+                    "reason",
+                    "id",
+                    "create_time",
+                    "update_time",
+                    "state",
+                    "refund_from_transaction_fee",
+                    "total_refunded_amount",
+                    "refund_from_received_amount",
+                    "sale_id",
+                    "capture_id",
+                    "parent_payment",
+                    "links"
+                ],
+                "properties": {
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "invoice_number": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "refund_from_transaction_fee": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "total_refunded_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "refund_from_received_amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "sale_id": {
+                        "type": "string"
+                    },
+                    "capture_id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v1_shipping": {
                 "required": [
                     "trackers"
@@ -3147,6 +2784,38 @@
                         "items": {
                             "$ref": "#/components/schemas/paypal_v1_shipping_tracker"
                         }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_shipping_tracker": {
+                "required": [
+                    "transaction_id",
+                    "tracking_number",
+                    "status",
+                    "carrier",
+                    "notify_buyer",
+                    "shipment_date"
+                ],
+                "properties": {
+                    "transaction_id": {
+                        "type": "string"
+                    },
+                    "tracking_number": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "carrier": {
+                        "type": "string"
+                    },
+                    "notify_buyer": {
+                        "type": "boolean"
+                    },
+                    "shipment_date": {
+                        "type": "string",
+                        "format": "date-time"
                     }
                 },
                 "type": "object"
@@ -3218,206 +2887,138 @@
                 },
                 "type": "object"
             },
-            "paypal_v1_disputes": {
+            "paypal_v1_subscription_application_context": {
                 "required": [
-                    "items",
-                    "links"
+                    "brand_name",
+                    "locale",
+                    "return_url",
+                    "cancel_url"
                 ],
                 "properties": {
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_disputes_item"
-                        },
-                        "nullable": true
+                    "user_action": {
+                        "type": "string",
+                        "default": "SUBSCRIBE_NOW"
                     },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
+                    "brand_name": {
+                        "type": "string"
+                    },
+                    "locale": {
+                        "type": "string"
+                    },
+                    "shipping_preference": {
+                        "type": "string",
+                        "default": "SET_PROVIDED_ADDRESS"
+                    },
+                    "return_url": {
+                        "type": "string"
+                    },
+                    "cancel_url": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v1_capture_transaction_fee": {
+            "paypal_v1_subscription_billing_info": {
+                "required": [
+                    "outstanding_balance",
+                    "cycle_executions",
+                    "last_payment",
+                    "next_billing_time",
+                    "failed_payments_count"
+                ],
+                "properties": {
+                    "outstanding_balance": {
+                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_outstanding_balance"
+                    },
+                    "cycle_executions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_cycle_execution"
+                        }
+                    },
+                    "last_payment": {
+                        "$ref": "#/components/schemas/paypal_v1_subscription_billing_info_last_payment"
+                    },
+                    "next_billing_time": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "failed_payments_count": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_billing_info_cycle_execution": {
+                "required": [
+                    "tenure_type",
+                    "sequence",
+                    "cycles_completed",
+                    "cycles_remaining",
+                    "total_cycles"
+                ],
+                "properties": {
+                    "tenure_type": {
+                        "type": "string"
+                    },
+                    "sequence": {
+                        "type": "integer"
+                    },
+                    "cycles_completed": {
+                        "type": "integer"
+                    },
+                    "cycles_remaining": {
+                        "type": "integer"
+                    },
+                    "total_cycles": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_billing_info_last_payment": {
+                "required": [
+                    "amount",
+                    "time"
+                ],
+                "properties": {
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
+                    },
+                    "time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_billing_info_outstanding_balance": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                        "$ref": "#/components/schemas/paypal_v1_common_money"
                     }
                 ]
             },
-            "paypal_v1_merchant_integrations_oauth_integration": {
+            "paypal_v1_subscription_subscriber": {
                 "required": [
-                    "integrationMethod",
-                    "integrationType",
-                    "oauthThirdParty"
+                    "name",
+                    "email_address",
+                    "payer_id",
+                    "shipping_address"
                 ],
                 "properties": {
-                    "integration_method": {
-                        "type": "string"
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_name"
                     },
-                    "integration_type": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "oauth_third_party": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_merchant_integrations_oauth_integration_oauth_third_party"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_oauth_integration_oauth_third_party": {
-                "required": [
-                    "merchantClientId",
-                    "partnerClientId",
-                    "scopes"
-                ],
-                "properties": {
-                    "access_token": {
-                        "type": "string"
-                    },
-                    "merchant_client_id": {
-                        "type": "string"
-                    },
-                    "partner_client_id": {
-                        "type": "string"
-                    },
-                    "refresh_token": {
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_credentials": {
-                "required": [
-                    "client_id",
-                    "client_secret",
-                    "payer_id"
-                ],
-                "properties": {
-                    "client_id": {
-                        "type": "string"
-                    },
-                    "client_secret": {
+                    "email_address": {
                         "type": "string"
                     },
                     "payer_id": {
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_capability": {
-                "required": [
-                    "name",
-                    "status"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
                     },
-                    "status": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_merchant_integrations_product": {
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "vetting_status": {
-                        "type": "string"
-                    },
-                    "capabilities": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v1_payment": {
-                "required": [
-                    "id",
-                    "state",
-                    "cart",
-                    "payer",
-                    "transactions",
-                    "create_time",
-                    "update_time",
-                    "links",
-                    "redirect_urls",
-                    "application_context",
-                    "payment_instruction"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "intent": {
-                        "type": "string",
-                        "default": "sale",
-                        "enum": [
-                            "sale",
-                            "authorize",
-                            "order"
-                        ]
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "cart": {
-                        "type": "string"
-                    },
-                    "payer": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_payer"
-                    },
-                    "transactions": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_payment_transaction"
-                        }
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v1_common_link"
-                        }
-                    },
-                    "redirect_urls": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_redirect_urls"
-                    },
-                    "application_context": {
-                        "$ref": "#/components/schemas/paypal_v1_payment_application_context"
-                    },
-                    "payment_instruction": {
+                    "shipping_address": {
                         "oneOf": [
                             {
-                                "$ref": "#/components/schemas/paypal_v1_payment_payment_instruction"
+                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address"
                             }
                         ],
                         "nullable": true
@@ -3425,64 +3026,926 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_referral": {
+            "paypal_v1_subscription_subscriber_name": {
                 "required": [
-                    "business_entity",
-                    "preferred_language_code",
-                    "tracking_id",
-                    "partner_config_override",
-                    "operations",
-                    "products",
-                    "capabilities",
-                    "legal_consents",
-                    "links",
-                    "legal_country_code"
+                    "given_name",
+                    "surname"
                 ],
                 "properties": {
-                    "business_entity": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_business_entity"
-                    },
-                    "preferred_language_code": {
+                    "given_name": {
                         "type": "string"
                     },
-                    "tracking_id": {
+                    "surname": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_subscriber_shipping_address": {
+                "required": [
+                    "name",
+                    "address"
+                ],
+                "properties": {
+                    "name": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_name"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "address": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_subscription_subscriber_shipping_address_address"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_subscriber_shipping_address_address": {
+                "required": [
+                    "address_line_1",
+                    "address_line_2",
+                    "admin_area_1",
+                    "admin_area_2",
+                    "postal_code",
+                    "country_code"
+                ],
+                "properties": {
+                    "address_line_1": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "address_line_2": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "admin_area_1": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "admin_area_2": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "postal_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "country_code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_subscription_subscriber_shipping_address_name": {
+                "required": [
+                    "full_name"
+                ],
+                "properties": {
+                    "full_name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_token": {
+                "required": [
+                    "scope",
+                    "nonce",
+                    "access_token",
+                    "token_type",
+                    "app_id",
+                    "id_token",
+                    "expires_in",
+                    "expire_date_time"
+                ],
+                "properties": {
+                    "scope": {
+                        "description": "Scopes expressed in the form of resource URL endpoints. The value of the scope parameter\nis expressed as a list of space-delimited, case-sensitive strings.",
                         "type": "string"
                     },
-                    "partner_config_override": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_partner_config_override"
+                    "nonce": {
+                        "type": "string"
                     },
-                    "operations": {
+                    "access_token": {
+                        "description": "The access token issued by PayPal. After the access token\nexpires (see $expiresIn), you must request a new access token.",
+                        "type": "string"
+                    },
+                    "token_type": {
+                        "description": "The type of the token issued as described in OAuth2.0 RFC6749,\nSection 7.1. Value is case insensitive.",
+                        "type": "string"
+                    },
+                    "app_id": {
+                        "type": "string"
+                    },
+                    "id_token": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "expires_in": {
+                        "description": "The lifetime of the access token, in seconds.",
+                        "type": "integer"
+                    },
+                    "expire_date_time": {
+                        "description": "Calculated expiration date",
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook": {
+                "required": [
+                    "id",
+                    "url",
+                    "event_types",
+                    "links"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string",
+                        "maxLength": 2048
+                    },
+                    "event_types": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v2_referral_operation"
+                            "$ref": "#/components/schemas/paypal_v1_webhook_event_type"
                         }
                     },
-                    "products": {
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_event": {
+                "required": [
+                    "id",
+                    "resource_type",
+                    "event_type",
+                    "summary",
+                    "resource",
+                    "create_time",
+                    "links",
+                    "event_version",
+                    "resource_version"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "resource_type": {
+                        "type": "string"
+                    },
+                    "event_type": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "resource": {
+                        "nullable": true,
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v3_payment_token"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_webhook_resource"
+                            },
+                            {
+                                "$ref": "#/components/schemas/paypal_v1_subscription"
+                            }
+                        ]
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "event_version": {
+                        "type": "string"
+                    },
+                    "resource_version": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_event_type": {
+                "required": [
+                    "name",
+                    "description",
+                    "status",
+                    "resource_version"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "resource_version": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_resource": {
+                "required": [
+                    "id",
+                    "parent_payment",
+                    "billing_agreement_id",
+                    "sale_id",
+                    "refund_reason_code",
+                    "update_time",
+                    "amount",
+                    "payment_mode",
+                    "create_time",
+                    "clearing_time",
+                    "protection_eligibility_type",
+                    "protection_eligibility",
+                    "transaction_fee",
+                    "invoice_number",
+                    "links",
+                    "state",
+                    "merchant_id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "parent_payment": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "billing_agreement_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sale_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "refund_reason_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v1_common_amount"
+                    },
+                    "payment_mode": {
+                        "type": "string"
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "clearing_time": {
+                        "type": "string"
+                    },
+                    "protection_eligibility_type": {
+                        "type": "string"
+                    },
+                    "protection_eligibility": {
+                        "type": "string"
+                    },
+                    "transaction_fee": {
+                        "$ref": "#/components/schemas/paypal_v1_common_value"
+                    },
+                    "invoice_number": {
+                        "type": "string"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_common_link"
+                        }
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "merchant_id": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v1_webhook_list": {
+                "required": [
+                    "webhooks"
+                ],
+                "properties": {
+                    "webhooks": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v1_webhook"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_address": {
+                "required": [
+                    "address_line_1",
+                    "address_line_2",
+                    "admin_area_2",
+                    "admin_area_1",
+                    "postal_code",
+                    "country_code"
+                ],
+                "properties": {
+                    "address_line_1": {
+                        "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 300
+                    },
+                    "address_line_2": {
+                        "description": "The second line of the address. For example, suite or apartment number.",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 300
+                    },
+                    "admin_area_2": {
+                        "description": "A city, town, or village. Smaller than $adminArea1",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 120
+                    },
+                    "admin_area_1": {
+                        "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 300
+                    },
+                    "postal_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 60
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_link": {
+                "required": [
+                    "href",
+                    "rel",
+                    "method",
+                    "enc_type"
+                ],
+                "properties": {
+                    "href": {
+                        "type": "string"
+                    },
+                    "rel": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "type": "string"
+                    },
+                    "enc_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_money": {
+                "required": [
+                    "currency_code",
+                    "value"
+                ],
+                "properties": {
+                    "currency_code": {
+                        "type": "string",
+                        "maxLength": 3,
+                        "minLength": 3
+                    },
+                    "value": {
+                        "type": "string",
+                        "maxLength": 30
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_name": {
+                "required": [
+                    "given_name",
+                    "surname"
+                ],
+                "properties": {
+                    "given_name": {
+                        "type": "string",
+                        "maxLength": 140
+                    },
+                    "surname": {
+                        "type": "string",
+                        "maxLength": 140
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_phone_number": {
+                "required": [
+                    "national_number",
+                    "country_code"
+                ],
+                "properties": {
+                    "national_number": {
+                        "type": "string",
+                        "maxLength": 3,
+                        "minLength": 1
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 14,
+                        "minLength": 1
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_common_upc": {
+                "required": [
+                    "type",
+                    "code"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "maxLength": 5,
+                        "minLength": 1
+                    },
+                    "code": {
+                        "type": "string",
+                        "maxLength": 17,
+                        "minLength": 6
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_confirm_order": {
+                "required": [
+                    "payment_source"
+                ],
+                "properties": {
+                    "payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data": {
+                "required": [
+                    "eligible_methods",
+                    "supplementary_data"
+                ],
+                "properties": {
+                    "eligible_methods": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods"
+                    },
+                    "supplementary_data": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_supplementary_data"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods": {
+                "required": [
+                    "paypal",
+                    "paypal_pay_later",
+                    "apple_pay",
+                    "google_pay",
+                    "advanced_cards",
+                    "eps",
+                    "p_2_4",
+                    "blik",
+                    "ideal",
+                    "bizum",
+                    "bancontact",
+                    "klarna"
+                ],
+                "properties": {
+                    "paypal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    "paypal_pay_later": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"
+                    },
+                    "apple_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_apple_pay"
+                    },
+                    "google_pay": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_google_pay"
+                    },
+                    "advanced_cards": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"
+                    },
+                    "eps": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_eps"
+                    },
+                    "p_2_4": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_p24"
+                    },
+                    "blik": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_blik"
+                    },
+                    "ideal": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_ideal"
+                    },
+                    "bizum": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bizum"
+                    },
+                    "bancontact": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bancontact"
+                    },
+                    "klarna": {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_klarna"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards": {
+                "required": [
+                    "supports_installements",
+                    "cobranded_enabled",
+                    "vendors"
+                ],
+                "properties": {
+                    "supports_installements": {
+                        "type": "boolean"
+                    },
+                    "cobranded_enabled": {
+                        "type": "boolean"
+                    },
+                    "vendors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "eligible",
+                            "network",
+                            "branded"
+                        ],
+                        "properties": {
+                            "eligible": {
+                                "type": "boolean"
+                            },
+                            "network": {
+                                "type": "string"
+                            },
+                            "branded": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_apple_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_bancontact": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_bizum": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_blik": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_eps": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_google_pay": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "config"
+                        ],
+                        "properties": {
+                            "config": {
+                                "type": "array",
+                                "items": {
+                                    "type": "mixed"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_ideal": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_klarna": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_p24": {
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal": {
+                "required": [
+                    "can_be_vaulted"
+                ],
+                "properties": {
+                    "can_be_vaulted": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
+                    },
+                    {
+                        "required": [
+                            "country_code",
+                            "product_code"
+                        ],
+                        "properties": {
+                            "country_code": {
+                                "description": "ISO 3166-1 alpha-2 country code",
+                                "type": "string",
+                                "maxLength": 2,
+                                "minLength": 2
+                            },
+                            "product_code": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "paypal_v2_eligible_methods_data_supplementary_data": {
+                "required": [
+                    "buyer_country_code"
+                ],
+                "properties": {
+                    "buyer_country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods": {
+                "required": [
+                    "customer",
+                    "preferences",
+                    "purchase_units"
+                ],
+                "properties": {
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer"
+                    },
+                    "preferences": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences"
+                    },
+                    "purchase_units": {
+                        "description": "Does not have to be a full purchase unit.\n`[{\"amount\":{\"currency_code\":\"<iso-4217-code>\"},\"payee\":{\"merchant_id\":\"<merchant-id>\"}}]` is enough.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer": {
+                "required": [
+                    "country_code",
+                    "channel"
+                ],
+                "properties": {
+                    "country_code": {
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "channel": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer_channel"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_customer_channel": {
+                "required": [
+                    "browser_type",
+                    "client_os",
+                    "device_type"
+                ],
+                "properties": {
+                    "browser_type": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "client_os": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "device_type": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences": {
+                "required": [
+                    "payment_flow",
+                    "commit",
+                    "intent",
+                    "vault",
+                    "payment_source_constraint"
+                ],
+                "properties": {
+                    "payment_flow": {
+                        "type": "string",
+                        "enum": [
+                            "ONE_TIME_PAYMENT"
+                        ]
+                    },
+                    "commit": {
+                        "type": "boolean"
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": [
+                            "CAPTURE",
+                            "AUTHORIZE"
+                        ]
+                    },
+                    "vault": {
+                        "type": "boolean"
+                    },
+                    "payment_source_constraint": {
+                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences_payment_source_constraint"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_find_eligible_methods_preferences_payment_source_constraint": {
+                "required": [
+                    "constraint_type",
+                    "payment_sources"
+                ],
+                "properties": {
+                    "constraint_type": {
+                        "type": "string",
+                        "enum": [
+                            "INCLUDE"
+                        ]
+                    },
+                    "payment_sources": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order": {
+                "required": [
+                    "create_time",
+                    "update_time",
+                    "id",
+                    "intent",
+                    "payer",
+                    "purchase_units",
+                    "application_context",
+                    "payment_source",
+                    "status",
+                    "processing_instruction",
+                    "links"
+                ],
+                "properties": {
+                    "create_time": {
+                        "type": "string"
                     },
-                    "capabilities": {
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": [
+                            "CAPTURE",
+                            "AUTHORIZE"
+                        ]
+                    },
+                    "payer": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payer"
+                    },
+                    "purchase_units": {
                         "type": "array",
                         "items": {
-                            "type": "string"
-                        }
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                        },
+                        "nullable": true
                     },
-                    "legal_consents": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_referral_legal_consent"
-                        }
+                    "application_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_application_context"
+                    },
+                    "payment_source": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "processing_instruction": {
+                        "type": "string"
                     },
                     "links": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
-                    },
-                    "legal_country_code": {
-                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -3528,1187 +3991,6 @@
                     },
                     "cancel_url": {
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_tracker": {
-                "required": [
-                    "capture_id",
-                    "tracking_number",
-                    "carrier",
-                    "carrier_name_other",
-                    "items"
-                ],
-                "properties": {
-                    "capture_id": {
-                        "type": "string"
-                    },
-                    "tracking_number": {
-                        "type": "string",
-                        "maxLength": 64
-                    },
-                    "carrier": {
-                        "type": "string"
-                    },
-                    "carrier_name_other": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "notify_payer": {
-                        "type": "boolean",
-                        "default": false
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker_item"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit": {
-                "required": [
-                    "reference_id",
-                    "amount",
-                    "payee",
-                    "description",
-                    "custom_id",
-                    "invoice_id",
-                    "items",
-                    "shipping",
-                    "payments",
-                    "supplementary_data",
-                    "shipping_options"
-                ],
-                "properties": {
-                    "reference_id": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount"
-                    },
-                    "payee": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "custom_id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "invoice_id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
-                        },
-                        "nullable": true
-                    },
-                    "shipping": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping"
-                    },
-                    "payments": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "supplementary_data": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data"
-                    },
-                    "shipping_options": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_google_pay": {
-                "required": [
-                    "experience_context",
-                    "card",
-                    "attributes"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "card": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_afterpay": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email",
-                    "phone",
-                    "birth_date"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "type": "string"
-                    },
-                    "birth_date": {
-                        "type": "string",
-                        "format": "date"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_oxxo": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_klarna": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email",
-                    "phone"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_blik": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_token_stored_payment_source": {
-                "required": [
-                    "payment_initiator",
-                    "payment_type",
-                    "usage"
-                ],
-                "properties": {
-                    "payment_initiator": {
-                        "type": "string"
-                    },
-                    "payment_type": {
-                        "type": "string"
-                    },
-                    "usage": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_pay_upon_invoice": {
-                "required": [
-                    "experience_context",
-                    "name",
-                    "email",
-                    "birth_date",
-                    "phone",
-                    "billing_address",
-                    "payment_reference",
-                    "deposit_bank_details"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_common_name"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "birth_date": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                    },
-                    "billing_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "payment_reference": {
-                        "type": "string"
-                    },
-                    "deposit_bank_details": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_boletobancario_tax_info": {
-                "required": [
-                    "tax_id",
-                    "tax_id_type"
-                ],
-                "properties": {
-                    "tax_id": {
-                        "type": "string"
-                    },
-                    "tax_id_type": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_eps": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_token": {
-                "required": [
-                    "experience_context",
-                    "id",
-                    "type",
-                    "stored_payment_source"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "stored_payment_source": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_token_stored_payment_source"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_p24": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card_stored_credential": {
-                "required": [
-                    "payment_initiator",
-                    "payment_type",
-                    "usage",
-                    "previous_network_transaction_reference"
-                ],
-                "properties": {
-                    "payment_initiator": {
-                        "type": "string",
-                        "enum": [
-                            "MERCHANT",
-                            "CUSTOMER"
-                        ]
-                    },
-                    "payment_type": {
-                        "type": "string",
-                        "enum": [
-                            "RECURRING",
-                            "ONE_TIME",
-                            "UNSCHEDULED"
-                        ]
-                    },
-                    "usage": {
-                        "type": "string",
-                        "enum": [
-                            "DERIVED",
-                            "FIRST",
-                            "SUBSEQUENT"
-                        ]
-                    },
-                    "previous_network_transaction_reference": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card_authentication_result": {
-                "required": [
-                    "liability_shift",
-                    "three_d_secure"
-                ],
-                "properties": {
-                    "liability_shift": {
-                        "type": "string"
-                    },
-                    "three_d_secure": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result_3d_secure"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card_authentication_result_3d_secure": {
-                "required": [
-                    "enrollment_status",
-                    "authentication_status"
-                ],
-                "properties": {
-                    "enrollment_status": {
-                        "type": "string"
-                    },
-                    "authentication_status": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_phone": {
-                "required": [
-                    "phone_type",
-                    "phone_number"
-                ],
-                "properties": {
-                    "phone_type": {
-                        "type": "string"
-                    },
-                    "phone_number": {
-                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_customer": {
-                "required": [
-                    "id"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_vault": {
-                "required": [
-                    "id",
-                    "store_in_vault",
-                    "usage_type",
-                    "status",
-                    "confirm_payment_token",
-                    "permit_multiple_payment_tokens",
-                    "customer",
-                    "links"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "store_in_vault": {
-                        "type": "string"
-                    },
-                    "usage_type": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "confirm_payment_token": {
-                        "type": "string"
-                    },
-                    "permit_multiple_payment_tokens": {
-                        "type": "boolean"
-                    },
-                    "customer": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_order_update_callback_config": {
-                "required": [
-                    "callback_url",
-                    "callback_events"
-                ],
-                "properties": {
-                    "callback_url": {
-                        "type": "string"
-                    },
-                    "callback_events": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "enum": [
-                                "SHIPPING_ADDRESS",
-                                "SHIPPING_OPTIONS"
-                            ]
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes_verification": {
-                "required": [
-                    "method"
-                ],
-                "properties": {
-                    "method": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context": {
-                "required": [
-                    "buyer_user_agent"
-                ],
-                "properties": {
-                    "return_flow": {
-                        "type": "string",
-                        "default": "AUTO",
-                        "enum": [
-                            "AUTO",
-                            "MANUAL"
-                        ]
-                    },
-                    "buyer_user_agent": {
-                        "type": "string",
-                        "maxLength": 512,
-                        "minLength": 1
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_app_switch_context_native_app_context": {
-                "required": [
-                    "os_type",
-                    "os_version"
-                ],
-                "properties": {
-                    "os_type": {
-                        "type": "string",
-                        "enum": [
-                            "ANDROID",
-                            "IOS",
-                            "OTHER"
-                        ]
-                    },
-                    "os_version": {
-                        "type": "string",
-                        "maxLength": 64,
-                        "minLength": 1
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_app_switch_context": {
-                "required": [
-                    "native_app",
-                    "mobile_web"
-                ],
-                "properties": {
-                    "native_app": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_native_app_context"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "mobile_web": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_experience_context": {
-                "required": [
-                    "locale",
-                    "brand_name",
-                    "logo_url",
-                    "return_url",
-                    "cancel_url",
-                    "payment_method_preference",
-                    "customer_service_instructions",
-                    "order_update_callback_config",
-                    "app_switch_context"
-                ],
-                "properties": {
-                    "locale": {
-                        "type": "string"
-                    },
-                    "brand_name": {
-                        "type": "string"
-                    },
-                    "logo_url": {
-                        "type": "string"
-                    },
-                    "landing_page": {
-                        "type": "string",
-                        "default": "NO_PREFERENCE",
-                        "enum": [
-                            "LOGIN",
-                            "GUEST_CHECKOUT",
-                            "NO_PREFERENCE"
-                        ]
-                    },
-                    "shipping_preference": {
-                        "type": "string",
-                        "default": "SET_PROVIDED_ADDRESS",
-                        "enum": [
-                            "SET_PROVIDED_ADDRESS",
-                            "NO_SHIPPING",
-                            "GET_FROM_FILE"
-                        ]
-                    },
-                    "user_action": {
-                        "type": "string",
-                        "default": "PAY_NOW",
-                        "enum": [
-                            "CONTINUE",
-                            "PAY_NOW"
-                        ]
-                    },
-                    "return_url": {
-                        "type": "string"
-                    },
-                    "cancel_url": {
-                        "type": "string"
-                    },
-                    "payment_method_preference": {
-                        "description": "Only: PayPal Wallet",
-                        "type": "string",
-                        "enum": [
-                            "UNRESTRICTED",
-                            "IMMEDIATE_PAYMENT_REQUIRED"
-                        ]
-                    },
-                    "customer_service_instructions": {
-                        "description": "Only: PUI",
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "order_update_callback_config": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_order_update_callback_config"
-                    },
-                    "app_switch_context": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_common_attributes": {
-                "required": [
-                    "vault",
-                    "customer",
-                    "verification"
-                ],
-                "properties": {
-                    "vault": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_vault"
-                    },
-                    "customer": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
-                    },
-                    "verification": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_verification"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_bancontact": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_my_bank": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_trustly": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_paypal": {
-                "required": [
-                    "experience_context",
-                    "email_address",
-                    "account_id",
-                    "billing_agreement_id",
-                    "vault_id",
-                    "name",
-                    "phone_number",
-                    "address",
-                    "birth_date",
-                    "phone_type",
-                    "attributes"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email_address": {
-                        "type": "string"
-                    },
-                    "account_id": {
-                        "type": "string"
-                    },
-                    "billing_agreement_id": {
-                        "type": "string"
-                    },
-                    "vault_id": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_common_name"
-                    },
-                    "phone_number": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "birth_date": {
-                        "type": "string"
-                    },
-                    "phone_type": {
-                        "type": "string"
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details": {
-                "required": [
-                    "bic",
-                    "bank_name",
-                    "iban",
-                    "account_holder_name"
-                ],
-                "properties": {
-                    "bic": {
-                        "type": "string"
-                    },
-                    "bank_name": {
-                        "type": "string"
-                    },
-                    "iban": {
-                        "type": "string"
-                    },
-                    "account_holder_name": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_boletobancario": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "email",
-                    "expiry_date",
-                    "tax_info",
-                    "billing_address"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "expiry_date": {
-                        "type": "string"
-                    },
-                    "tax_info": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_boletobancario_tax_info"
-                    },
-                    "billing_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_card": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "last_digits",
-                    "brand",
-                    "type",
-                    "vault_id",
-                    "billing_address",
-                    "authentication_result",
-                    "attributes",
-                    "stored_credential"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "last_digits": {
-                        "type": "string"
-                    },
-                    "brand": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "vault_id": {
-                        "type": "string"
-                    },
-                    "billing_address": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_address"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "authentication_result": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "stored_credential": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_stored_credential"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_ideal": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_swish": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "phone"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "phone": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_venmo": {
-                "required": [
-                    "experience_context",
-                    "email_address",
-                    "user_name",
-                    "account_id",
-                    "vault_id",
-                    "name",
-                    "phone_number",
-                    "address",
-                    "attributes"
-                ],
-                "properties": {
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "email_address": {
-                        "type": "string"
-                    },
-                    "user_name": {
-                        "type": "string"
-                    },
-                    "account_id": {
-                        "type": "string"
-                    },
-                    "vault_id": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_common_name"
-                    },
-                    "phone_number": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_apple_pay": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context",
-                    "card",
-                    "attributes"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
-                    },
-                    "card": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "attributes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_payment_source_multibanco": {
-                "required": [
-                    "name",
-                    "country_code",
-                    "experience_context"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 300,
-                        "minLength": 3
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "experience_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
                     }
                 },
                 "type": "object"
@@ -4927,24 +4209,1175 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payee": {
+            "paypal_v2_order_payment_source_afterpay": {
                 "required": [
-                    "email_address",
-                    "merchant_id",
-                    "display_data"
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone",
+                    "birth_date"
                 ],
                 "properties": {
-                    "email_address": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
                         "type": "string"
                     },
-                    "merchant_id": {
+                    "phone": {
                         "type": "string"
                     },
-                    "display_data": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee_display_data"
+                    "birth_date": {
+                        "type": "string",
+                        "format": "date"
                     }
                 },
                 "type": "object"
+            },
+            "paypal_v2_order_payment_source_apple_pay": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "card",
+                    "attributes"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "card": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_bancontact": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_blik": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_boletobancario": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "expiry_date",
+                    "tax_info",
+                    "billing_address"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "expiry_date": {
+                        "type": "string"
+                    },
+                    "tax_info": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_boletobancario_tax_info"
+                    },
+                    "billing_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_boletobancario_tax_info": {
+                "required": [
+                    "tax_id",
+                    "tax_id_type"
+                ],
+                "properties": {
+                    "tax_id": {
+                        "type": "string"
+                    },
+                    "tax_id_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "last_digits",
+                    "brand",
+                    "type",
+                    "vault_id",
+                    "billing_address",
+                    "authentication_result",
+                    "attributes",
+                    "stored_credential"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "last_digits": {
+                        "type": "string"
+                    },
+                    "brand": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "vault_id": {
+                        "type": "string"
+                    },
+                    "billing_address": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_address"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "authentication_result": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "stored_credential": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_stored_credential"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card_authentication_result": {
+                "required": [
+                    "liability_shift",
+                    "three_d_secure"
+                ],
+                "properties": {
+                    "liability_shift": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "three_d_secure": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card_authentication_result_3d_secure"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card_authentication_result_3d_secure": {
+                "required": [
+                    "enrollment_status",
+                    "authentication_status"
+                ],
+                "properties": {
+                    "enrollment_status": {
+                        "type": "string"
+                    },
+                    "authentication_status": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_card_stored_credential": {
+                "required": [
+                    "payment_initiator",
+                    "payment_type",
+                    "usage",
+                    "previous_network_transaction_reference"
+                ],
+                "properties": {
+                    "payment_initiator": {
+                        "type": "string",
+                        "enum": [
+                            "MERCHANT",
+                            "CUSTOMER"
+                        ]
+                    },
+                    "payment_type": {
+                        "type": "string",
+                        "enum": [
+                            "RECURRING",
+                            "ONE_TIME",
+                            "UNSCHEDULED"
+                        ]
+                    },
+                    "usage": {
+                        "type": "string",
+                        "enum": [
+                            "DERIVED",
+                            "FIRST",
+                            "SUBSEQUENT"
+                        ]
+                    },
+                    "previous_network_transaction_reference": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_app_switch_context": {
+                "required": [
+                    "native_app",
+                    "mobile_web"
+                ],
+                "properties": {
+                    "native_app": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_native_app_context"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "mobile_web": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context": {
+                "required": [
+                    "buyer_user_agent"
+                ],
+                "properties": {
+                    "return_flow": {
+                        "type": "string",
+                        "default": "AUTO",
+                        "enum": [
+                            "AUTO",
+                            "MANUAL"
+                        ]
+                    },
+                    "buyer_user_agent": {
+                        "type": "string",
+                        "maxLength": 512,
+                        "minLength": 1
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_app_switch_context_native_app_context": {
+                "required": [
+                    "os_type",
+                    "os_version"
+                ],
+                "properties": {
+                    "os_type": {
+                        "type": "string",
+                        "enum": [
+                            "ANDROID",
+                            "IOS",
+                            "OTHER"
+                        ]
+                    },
+                    "os_version": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "minLength": 1
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes": {
+                "required": [
+                    "vault",
+                    "customer",
+                    "verification"
+                ],
+                "properties": {
+                    "vault": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_vault"
+                    },
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
+                    },
+                    "verification": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_verification"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_customer": {
+                "required": [
+                    "id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_order_update_callback_config": {
+                "required": [
+                    "callback_url",
+                    "callback_events"
+                ],
+                "properties": {
+                    "callback_url": {
+                        "type": "string"
+                    },
+                    "callback_events": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "SHIPPING_ADDRESS",
+                                "SHIPPING_OPTIONS"
+                            ]
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_vault": {
+                "required": [
+                    "id",
+                    "store_in_vault",
+                    "usage_type",
+                    "status",
+                    "confirm_payment_token",
+                    "permit_multiple_payment_tokens",
+                    "customer",
+                    "links"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "store_in_vault": {
+                        "type": "string"
+                    },
+                    "usage_type": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "confirm_payment_token": {
+                        "type": "string"
+                    },
+                    "permit_multiple_payment_tokens": {
+                        "type": "boolean"
+                    },
+                    "customer": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_attributes_verification": {
+                "required": [
+                    "method"
+                ],
+                "properties": {
+                    "method": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_experience_context": {
+                "required": [
+                    "locale",
+                    "brand_name",
+                    "logo_url",
+                    "return_url",
+                    "cancel_url",
+                    "payment_method_preference",
+                    "customer_service_instructions",
+                    "order_update_callback_config",
+                    "app_switch_context"
+                ],
+                "properties": {
+                    "locale": {
+                        "type": "string"
+                    },
+                    "brand_name": {
+                        "type": "string"
+                    },
+                    "logo_url": {
+                        "type": "string"
+                    },
+                    "landing_page": {
+                        "type": "string",
+                        "default": "NO_PREFERENCE",
+                        "enum": [
+                            "LOGIN",
+                            "GUEST_CHECKOUT",
+                            "NO_PREFERENCE"
+                        ]
+                    },
+                    "shipping_preference": {
+                        "type": "string",
+                        "default": "SET_PROVIDED_ADDRESS",
+                        "enum": [
+                            "SET_PROVIDED_ADDRESS",
+                            "NO_SHIPPING",
+                            "GET_FROM_FILE"
+                        ]
+                    },
+                    "user_action": {
+                        "type": "string",
+                        "default": "PAY_NOW",
+                        "enum": [
+                            "CONTINUE",
+                            "PAY_NOW"
+                        ]
+                    },
+                    "return_url": {
+                        "type": "string"
+                    },
+                    "cancel_url": {
+                        "type": "string"
+                    },
+                    "payment_method_preference": {
+                        "description": "Only: PayPal Wallet",
+                        "type": "string",
+                        "enum": [
+                            "UNRESTRICTED",
+                            "IMMEDIATE_PAYMENT_REQUIRED"
+                        ]
+                    },
+                    "customer_service_instructions": {
+                        "description": "Only: PUI",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "order_update_callback_config": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_order_update_callback_config"
+                    },
+                    "app_switch_context": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_app_switch_context"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_common_phone": {
+                "required": [
+                    "phone_type",
+                    "phone_number"
+                ],
+                "properties": {
+                    "phone_type": {
+                        "type": "string"
+                    },
+                    "phone_number": {
+                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_eps": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_google_pay": {
+                "required": [
+                    "experience_context",
+                    "card",
+                    "attributes"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "card": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_card"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_ideal": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_klarna": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_multibanco": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_my_bank": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_oxxo": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_p24": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "email"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_pay_upon_invoice": {
+                "required": [
+                    "experience_context",
+                    "name",
+                    "email",
+                    "birth_date",
+                    "phone",
+                    "billing_address",
+                    "payment_reference",
+                    "deposit_bank_details"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v2_common_name"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "birth_date": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                    },
+                    "billing_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "payment_reference": {
+                        "type": "string"
+                    },
+                    "deposit_bank_details": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details": {
+                "required": [
+                    "bic",
+                    "bank_name",
+                    "iban",
+                    "account_holder_name"
+                ],
+                "properties": {
+                    "bic": {
+                        "type": "string"
+                    },
+                    "bank_name": {
+                        "type": "string"
+                    },
+                    "iban": {
+                        "type": "string"
+                    },
+                    "account_holder_name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_paypal": {
+                "required": [
+                    "experience_context",
+                    "email_address",
+                    "account_id",
+                    "billing_agreement_id",
+                    "vault_id",
+                    "name",
+                    "phone_number",
+                    "address",
+                    "birth_date",
+                    "phone_type",
+                    "attributes"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email_address": {
+                        "type": "string"
+                    },
+                    "account_id": {
+                        "type": "string"
+                    },
+                    "billing_agreement_id": {
+                        "type": "string"
+                    },
+                    "vault_id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v2_common_name"
+                    },
+                    "phone_number": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "birth_date": {
+                        "type": "string"
+                    },
+                    "phone_type": {
+                        "type": "string"
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_swish": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context",
+                    "phone"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "phone": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_token": {
+                "required": [
+                    "experience_context",
+                    "id",
+                    "type",
+                    "stored_payment_source"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "stored_payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_token_stored_payment_source"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_token_stored_payment_source": {
+                "required": [
+                    "payment_initiator",
+                    "payment_type",
+                    "usage"
+                ],
+                "properties": {
+                    "payment_initiator": {
+                        "type": "string"
+                    },
+                    "payment_type": {
+                        "type": "string"
+                    },
+                    "usage": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_trustly": {
+                "required": [
+                    "name",
+                    "country_code",
+                    "experience_context"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "minLength": 3
+                    },
+                    "country_code": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "minLength": 2
+                    },
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_payment_source_venmo": {
+                "required": [
+                    "experience_context",
+                    "email_address",
+                    "user_name",
+                    "account_id",
+                    "vault_id",
+                    "name",
+                    "phone_number",
+                    "address",
+                    "attributes"
+                ],
+                "properties": {
+                    "experience_context": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_experience_context"
+                    },
+                    "email_address": {
+                        "type": "string"
+                    },
+                    "user_name": {
+                        "type": "string"
+                    },
+                    "account_id": {
+                        "type": "string"
+                    },
+                    "vault_id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/paypal_v2_common_name"
+                    },
+                    "phone_number": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_phone_number"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "attributes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit": {
+                "required": [
+                    "reference_id",
+                    "amount",
+                    "payee",
+                    "description",
+                    "custom_id",
+                    "invoice_id",
+                    "items",
+                    "shipping",
+                    "payments",
+                    "supplementary_data",
+                    "shipping_options"
+                ],
+                "properties": {
+                    "reference_id": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount"
+                    },
+                    "payee": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "custom_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "invoice_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
+                        },
+                        "nullable": true
+                    },
+                    "shipping": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping"
+                    },
+                    "payments": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "supplementary_data": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data"
+                    },
+                    "shipping_options": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_amount": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    {
+                        "required": [
+                            "breakdown"
+                        ],
+                        "properties": {
+                            "breakdown": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount_breakdown"
+                                    }
+                                ],
+                                "nullable": true
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
             },
             "paypal_v2_order_purchase_unit_amount_breakdown": {
                 "required": [
@@ -4982,6 +5415,190 @@
                     },
                     "discount": {
                         "$ref": "#/components/schemas/paypal_v2_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_item": {
+                "required": [
+                    "name",
+                    "unit_amount",
+                    "tax",
+                    "tax_rate",
+                    "category",
+                    "quantity",
+                    "sku"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 120
+                    },
+                    "unit_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "tax": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "tax_rate": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "float"
+                            }
+                        ]
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "PHYSICAL_GOODS",
+                            "DIGITAL_GOODS",
+                            "DONATION"
+                        ]
+                    },
+                    "quantity": {
+                        "type": "integer"
+                    },
+                    "sku": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 127
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payee": {
+                "required": [
+                    "email_address",
+                    "merchant_id",
+                    "display_data"
+                ],
+                "properties": {
+                    "email_address": {
+                        "type": "string"
+                    },
+                    "merchant_id": {
+                        "type": "string"
+                    },
+                    "display_data": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payee_display_data"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payee_display_data": {
+                "required": [
+                    "brand_name"
+                ],
+                "properties": {
+                    "brand_name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments": {
+                "required": [
+                    "authorizations",
+                    "captures",
+                    "refunds"
+                ],
+                "properties": {
+                    "authorizations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
+                        },
+                        "nullable": true
+                    },
+                    "captures": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
+                        },
+                        "nullable": true
+                    },
+                    "refunds": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_authorization": {
+                "required": [
+                    "status",
+                    "id",
+                    "amount",
+                    "custom_id",
+                    "links",
+                    "create_time",
+                    "update_time",
+                    "seller_protection",
+                    "expiration_time"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v2_common_money"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "custom_id": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    },
+                    "create_time": {
+                        "type": "string"
+                    },
+                    "update_time": {
+                        "type": "string"
+                    },
+                    "seller_protection": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
+                    },
+                    "expiration_time": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_authorization_seller_protection": {
+                "required": [
+                    "status",
+                    "dispute_categories"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "dispute_categories": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 },
                 "type": "object"
@@ -5062,6 +5679,65 @@
                 },
                 "type": "object"
             },
+            "paypal_v2_order_purchase_unit_payments_capture_processor_response": {
+                "required": [
+                    "avs_code",
+                    "cvv_code",
+                    "response_code"
+                ],
+                "properties": {
+                    "avs_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cvv_code": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "response_code": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown": {
+                "required": [
+                    "gross_amount",
+                    "paypal_fee",
+                    "net_amount"
+                ],
+                "properties": {
+                    "gross_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "paypal_fee": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "net_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_payments_common_seller_protection": {
+                "required": [
+                    "status",
+                    "dispute_categories"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "dispute_categories": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "paypal_v2_order_purchase_unit_payments_refund": {
                 "required": [
                     "status",
@@ -5122,76 +5798,6 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payments_authorization": {
-                "required": [
-                    "status",
-                    "id",
-                    "amount",
-                    "custom_id",
-                    "links",
-                    "create_time",
-                    "update_time",
-                    "seller_protection",
-                    "expiration_time"
-                ],
-                "properties": {
-                    "status": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_common_money"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "custom_id": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    },
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
-                    "seller_protection": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_common_seller_protection"
-                    },
-                    "expiration_time": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments_common_seller_protection": {
-                "required": [
-                    "status",
-                    "dispute_categories"
-                ],
-                "properties": {
-                    "status": {
-                        "type": "string"
-                    },
-                    "dispute_categories": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
             "paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown": {
                 "required": [
                     "gross_amount",
@@ -5215,160 +5821,25 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payments_authorization_seller_protection": {
-                "required": [
-                    "status",
-                    "dispute_categories"
-                ],
-                "properties": {
-                    "status": {
-                        "type": "string"
-                    },
-                    "dispute_categories": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments_capture_processor_response": {
-                "required": [
-                    "avs_code",
-                    "cvv_code",
-                    "response_code"
-                ],
-                "properties": {
-                    "avs_code": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "cvv_code": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "response_code": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown": {
-                "required": [
-                    "gross_amount",
-                    "paypal_fee",
-                    "net_amount"
-                ],
-                "properties": {
-                    "gross_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "paypal_fee": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "net_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_item": {
+            "paypal_v2_order_purchase_unit_shipping": {
                 "required": [
                     "name",
-                    "unit_amount",
-                    "tax",
-                    "tax_rate",
-                    "category",
-                    "quantity",
-                    "sku"
+                    "address",
+                    "trackers"
                 ],
                 "properties": {
                     "name": {
-                        "type": "string",
-                        "maxLength": 120
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_name"
                     },
-                    "unit_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
                     },
-                    "tax": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "tax_rate": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "float"
-                            }
-                        ]
-                    },
-                    "category": {
-                        "type": "string",
-                        "enum": [
-                            "PHYSICAL_GOODS",
-                            "DIGITAL_GOODS",
-                            "DONATION"
-                        ]
-                    },
-                    "quantity": {
-                        "type": "integer"
-                    },
-                    "sku": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 127
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_payments": {
-                "required": [
-                    "authorizations",
-                    "captures",
-                    "refunds"
-                ],
-                "properties": {
-                    "authorizations": {
+                    "trackers": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_authorization"
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker"
                         },
                         "nullable": true
-                    },
-                    "captures": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_capture"
-                        },
-                        "nullable": true
-                    },
-                    "refunds": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_payments_refund"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_supplementary_data": {
-                "required": [
-                    "card",
-                    "risk"
-                ],
-                "properties": {
-                    "card": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card"
-                    },
-                    "risk": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk"
                     }
                 },
                 "type": "object"
@@ -5380,6 +5851,39 @@
                 "properties": {
                     "full_name": {
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_shipping_tracker": {
+                "required": [
+                    "id",
+                    "status",
+                    "notify_payer",
+                    "links",
+                    "items"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "notify_payer": {
+                        "type": "boolean"
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
+                        }
                     }
                 },
                 "type": "object"
@@ -5418,39 +5922,6 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_shipping_tracker": {
-                "required": [
-                    "id",
-                    "status",
-                    "notify_payer",
-                    "links",
-                    "items"
-                ],
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "notify_payer": {
-                        "type": "boolean"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
-                        }
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_item"
-                        }
-                    }
-                },
-                "type": "object"
-            },
             "paypal_v2_order_purchase_unit_shipping_option": {
                 "required": [
                     "id",
@@ -5482,71 +5953,77 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_payee_display_data": {
+            "paypal_v2_order_purchase_unit_supplementary_data": {
                 "required": [
-                    "brand_name"
+                    "card",
+                    "risk"
                 ],
                 "properties": {
-                    "brand_name": {
-                        "type": "string"
+                    "card": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card"
+                    },
+                    "risk": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_amount": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    {
-                        "required": [
-                            "breakdown"
-                        ],
-                        "properties": {
-                            "breakdown": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_amount_breakdown"
-                                    }
-                                ],
-                                "nullable": true
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_order_purchase_unit_shipping": {
-                "required": [
-                    "name",
-                    "address",
-                    "trackers"
-                ],
-                "properties": {
-                    "name": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_name"
-                    },
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "trackers": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker"
-                        },
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_supplementary_data_risk": {
+            "paypal_v2_order_purchase_unit_supplementary_data_card": {
                 "required": [
                     "address"
                 ],
                 "properties": {
                     "address": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk_participant_metadata"
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_level2"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_supplementary_data_card_level2": {
+                "required": [
+                    "invoice_id",
+                    "tax_total"
+                ],
+                "properties": {
+                    "invoice_id": {
+                        "type": "string"
+                    },
+                    "tax_total": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_order_purchase_unit_supplementary_data_card_level3": {
+                "required": [
+                    "shipping_amount",
+                    "duty_amount",
+                    "discount_amount",
+                    "shipping_address",
+                    "ships_from_postal_code",
+                    "line_items"
+                ],
+                "properties": {
+                    "shipping_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "duty_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "discount_amount": {
+                        "$ref": "#/components/schemas/paypal_v2_common_money"
+                    },
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    },
+                    "ships_from_postal_code": {
+                        "type": "string"
+                    },
+                    "line_items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_line_item"
+                        }
                     }
                 },
                 "type": "object"
@@ -5622,51 +6099,13 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_supplementary_data_card_level2": {
+            "paypal_v2_order_purchase_unit_supplementary_data_risk": {
                 "required": [
-                    "invoice_id",
-                    "tax_total"
+                    "address"
                 ],
                 "properties": {
-                    "invoice_id": {
-                        "type": "string"
-                    },
-                    "tax_total": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_purchase_unit_supplementary_data_card_level3": {
-                "required": [
-                    "shipping_amount",
-                    "duty_amount",
-                    "discount_amount",
-                    "shipping_address",
-                    "ships_from_postal_code",
-                    "line_items"
-                ],
-                "properties": {
-                    "shipping_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "duty_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "discount_amount": {
-                        "$ref": "#/components/schemas/paypal_v2_common_money"
-                    },
-                    "shipping_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
-                    },
-                    "ships_from_postal_code": {
-                        "type": "string"
-                    },
-                    "line_items": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_line_item"
-                        }
+                    "address": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_risk_participant_metadata"
                     }
                 },
                 "type": "object"
@@ -5684,482 +6123,64 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_order_purchase_unit_supplementary_data_card": {
+            "paypal_v2_order_tracker": {
                 "required": [
-                    "address"
+                    "capture_id",
+                    "tracking_number",
+                    "carrier",
+                    "carrier_name_other",
+                    "items"
                 ],
                 "properties": {
-                    "address": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_supplementary_data_card_level2"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data": {
-                "required": [
-                    "eligible_methods",
-                    "supplementary_data"
-                ],
-                "properties": {
-                    "eligible_methods": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods"
+                    "capture_id": {
+                        "type": "string"
                     },
-                    "supplementary_data": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_supplementary_data"
+                    "tracking_number": {
+                        "type": "string",
+                        "maxLength": 64
+                    },
+                    "carrier": {
+                        "type": "string"
+                    },
+                    "carrier_name_other": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "notify_payer": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_tracker_item"
+                        }
                     }
                 },
                 "type": "object"
             },
-            "paypal_v2_find_eligible_methods": {
+            "paypal_v2_order_shipping_callback": {
                 "required": [
-                    "customer",
-                    "preferences",
+                    "id",
+                    "shipping_address",
+                    "shipping_option",
                     "purchase_units"
                 ],
                 "properties": {
-                    "customer": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer"
-                    },
-                    "preferences": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences"
-                    },
-                    "purchase_units": {
-                        "description": "Does not have to be a full purchase unit.\n`[{\"amount\":{\"currency_code\":\"<iso-4217-code>\"},\"payee\":{\"merchant_id\":\"<merchant-id>\"}}]` is enough.",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_google_pay": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "config"
-                        ],
-                        "properties": {
-                            "config": {
-                                "type": "array",
-                                "items": {
-                                    "type": "mixed"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_klarna": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_blik": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards": {
-                "required": [
-                    "supports_installements",
-                    "cobranded_enabled",
-                    "vendors"
-                ],
-                "properties": {
-                    "supports_installements": {
-                        "type": "boolean"
-                    },
-                    "cobranded_enabled": {
-                        "type": "boolean"
-                    },
-                    "vendors": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_bizum": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_eps": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_p24": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "eligible",
-                            "network",
-                            "branded"
-                        ],
-                        "properties": {
-                            "eligible": {
-                                "type": "boolean"
-                            },
-                            "network": {
-                                "type": "string"
-                            },
-                            "branded": {
-                                "type": "boolean"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "country_code",
-                            "product_code"
-                        ],
-                        "properties": {
-                            "country_code": {
-                                "description": "ISO 3166-1 alpha-2 country code",
-                                "type": "string",
-                                "maxLength": 2,
-                                "minLength": 2
-                            },
-                            "product_code": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_bancontact": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_paypal": {
-                "required": [
-                    "can_be_vaulted"
-                ],
-                "properties": {
-                    "can_be_vaulted": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_ideal": {
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods_apple_pay": {
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    {
-                        "required": [
-                            "config"
-                        ],
-                        "properties": {
-                            "config": {
-                                "type": "array",
-                                "items": {
-                                    "type": "mixed"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    }
-                ]
-            },
-            "paypal_v2_eligible_methods_data_supplementary_data": {
-                "required": [
-                    "buyer_country_code"
-                ],
-                "properties": {
-                    "buyer_country_code": {
-                        "description": "ISO 3166-1 alpha-2 country code",
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_eligible_methods_data_eligible_methods": {
-                "required": [
-                    "paypal",
-                    "paypal_pay_later",
-                    "apple_pay",
-                    "google_pay",
-                    "advanced_cards",
-                    "eps",
-                    "p_2_4",
-                    "blik",
-                    "ideal",
-                    "bizum",
-                    "bancontact",
-                    "klarna"
-                ],
-                "properties": {
-                    "paypal": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal"
-                    },
-                    "paypal_pay_later": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"
-                    },
-                    "apple_pay": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_apple_pay"
-                    },
-                    "google_pay": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_google_pay"
-                    },
-                    "advanced_cards": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"
-                    },
-                    "eps": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_eps"
-                    },
-                    "p_2_4": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_p24"
-                    },
-                    "blik": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_blik"
-                    },
-                    "ideal": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_ideal"
-                    },
-                    "bizum": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bizum"
-                    },
-                    "bancontact": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_bancontact"
-                    },
-                    "klarna": {
-                        "$ref": "#/components/schemas/paypal_v2_eligible_methods_data_eligible_methods_klarna"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order": {
-                "required": [
-                    "create_time",
-                    "update_time",
-                    "id",
-                    "intent",
-                    "payer",
-                    "purchase_units",
-                    "application_context",
-                    "payment_source",
-                    "status",
-                    "processing_instruction",
-                    "links"
-                ],
-                "properties": {
-                    "create_time": {
-                        "type": "string"
-                    },
-                    "update_time": {
-                        "type": "string"
-                    },
                     "id": {
                         "type": "string"
                     },
-                    "intent": {
-                        "type": "string",
-                        "enum": [
-                            "CAPTURE",
-                            "AUTHORIZE"
-                        ]
+                    "shipping_address": {
+                        "$ref": "#/components/schemas/paypal_v2_common_address"
                     },
-                    "payer": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payer"
+                    "shipping_option": {
+                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
                     },
                     "purchase_units": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
-                        },
-                        "nullable": true
-                    },
-                    "application_context": {
-                        "$ref": "#/components/schemas/paypal_v2_order_application_context"
-                    },
-                    "payment_source": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/paypal_v2_order_payment_source"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "processing_instruction": {
-                        "type": "string"
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_name": {
-                "required": [
-                    "given_name",
-                    "surname"
-                ],
-                "properties": {
-                    "given_name": {
-                        "type": "string",
-                        "maxLength": 140
-                    },
-                    "surname": {
-                        "type": "string",
-                        "maxLength": 140
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_phone_number": {
-                "required": [
-                    "national_number",
-                    "country_code"
-                ],
-                "properties": {
-                    "national_number": {
-                        "type": "string",
-                        "maxLength": 3,
-                        "minLength": 1
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 14,
-                        "minLength": 1
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_link": {
-                "required": [
-                    "href",
-                    "rel",
-                    "method",
-                    "enc_type"
-                ],
-                "properties": {
-                    "href": {
-                        "type": "string"
-                    },
-                    "rel": {
-                        "type": "string"
-                    },
-                    "method": {
-                        "type": "string"
-                    },
-                    "enc_type": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_upc": {
-                "required": [
-                    "type",
-                    "code"
-                ],
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "maxLength": 5,
-                        "minLength": 1
-                    },
-                    "code": {
-                        "type": "string",
-                        "maxLength": 17,
-                        "minLength": 6
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_address": {
-                "required": [
-                    "address_line_1",
-                    "address_line_2",
-                    "admin_area_2",
-                    "admin_area_1",
-                    "postal_code",
-                    "country_code"
-                ],
-                "properties": {
-                    "address_line_1": {
-                        "description": "The first line of the address. For example, number or street. For example, 173 Drury Lane.\nRequired for data entry and compliance and risk checks. Must contain the full address.",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 300
-                    },
-                    "address_line_2": {
-                        "description": "The second line of the address. For example, suite or apartment number.",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 300
-                    },
-                    "admin_area_2": {
-                        "description": "A city, town, or village. Smaller than $adminArea1",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 120
-                    },
-                    "admin_area_1": {
-                        "description": "The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.\nFormat for postal delivery. For example, CA and not California.",
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 300
-                    },
-                    "postal_code": {
-                        "type": "string",
-                        "nullable": true,
-                        "maxLength": 60
-                    },
-                    "country_code": {
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_common_money": {
-                "required": [
-                    "currency_code",
-                    "value"
-                ],
-                "properties": {
-                    "currency_code": {
-                        "type": "string",
-                        "maxLength": 3,
-                        "minLength": 3
-                    },
-                    "value": {
-                        "type": "string",
-                        "maxLength": 30
                     }
                 },
                 "type": "object"
@@ -6207,31 +6228,63 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_referral_operation": {
+            "paypal_v2_referral": {
                 "required": [
-                    "api_integration_preference"
+                    "business_entity",
+                    "preferred_language_code",
+                    "tracking_id",
+                    "partner_config_override",
+                    "operations",
+                    "products",
+                    "capabilities",
+                    "legal_consents",
+                    "links",
+                    "legal_country_code"
                 ],
                 "properties": {
-                    "operation": {
-                        "type": "string",
-                        "default": "API_INTEGRATION"
+                    "business_entity": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_business_entity"
                     },
-                    "api_integration_preference": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_referral_partner_config_override": {
-                "required": [
-                    "return_url",
-                    "partner_logo_url"
-                ],
-                "properties": {
-                    "return_url": {
+                    "preferred_language_code": {
                         "type": "string"
                     },
-                    "partner_logo_url": {
+                    "tracking_id": {
+                        "type": "string"
+                    },
+                    "partner_config_override": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_partner_config_override"
+                    },
+                    "operations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_referral_operation"
+                        }
+                    },
+                    "products": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "capabilities": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "legal_consents": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_referral_legal_consent"
+                        }
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
+                        }
+                    },
+                    "legal_country_code": {
                         "type": "string"
                     }
                 },
@@ -6247,6 +6300,62 @@
                         "items": {
                             "$ref": "#/components/schemas/paypal_v2_referral_business_entity_address"
                         }
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_business_entity_address": {
+                "required": [
+                    "country_code"
+                ],
+                "properties": {
+                    "country_code": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "default": "WORK"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_legal_consent": {
+                "required": [
+                    "granted"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "default": "SHARE_DATA_CONSENT"
+                    },
+                    "granted": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_operation": {
+                "required": [
+                    "api_integration_preference"
+                ],
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "default": "API_INTEGRATION"
+                    },
+                    "api_integration_preference": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference"
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v2_referral_operation_api_integration_preference": {
+                "required": [
+                    "rest_api_integration"
+                ],
+                "properties": {
+                    "rest_api_integration": {
+                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference_rest_api_integration"
                     }
                 },
                 "type": "object"
@@ -6293,175 +6402,67 @@
                 },
                 "type": "object"
             },
-            "paypal_v2_referral_operation_api_integration_preference": {
+            "paypal_v2_referral_partner_config_override": {
                 "required": [
-                    "rest_api_integration"
+                    "return_url",
+                    "partner_logo_url"
                 ],
                 "properties": {
-                    "rest_api_integration": {
-                        "$ref": "#/components/schemas/paypal_v2_referral_operation_api_integration_preference_rest_api_integration"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_referral_business_entity_address": {
-                "required": [
-                    "country_code"
-                ],
-                "properties": {
-                    "country_code": {
+                    "return_url": {
                         "type": "string"
                     },
-                    "type": {
-                        "type": "string",
-                        "default": "WORK"
+                    "partner_logo_url": {
+                        "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "paypal_v2_referral_legal_consent": {
-                "required": [
-                    "granted"
-                ],
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "default": "SHARE_DATA_CONSENT"
-                    },
-                    "granted": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_confirm_order": {
-                "required": [
-                    "payment_source"
-                ],
-                "properties": {
-                    "payment_source": {
-                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_customer_channel": {
-                "required": [
-                    "browser_type",
-                    "client_os",
-                    "device_type"
-                ],
-                "properties": {
-                    "browser_type": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "client_os": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "device_type": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_customer": {
-                "required": [
-                    "country_code",
-                    "channel"
-                ],
-                "properties": {
-                    "country_code": {
-                        "description": "ISO 3166-1 alpha-2 country code",
-                        "type": "string",
-                        "maxLength": 2,
-                        "minLength": 2
-                    },
-                    "channel": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_customer_channel"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_preferences_payment_source_constraint": {
-                "required": [
-                    "constraint_type",
-                    "payment_sources"
-                ],
-                "properties": {
-                    "constraint_type": {
-                        "type": "string",
-                        "enum": [
-                            "INCLUDE"
-                        ]
-                    },
-                    "payment_sources": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_find_eligible_methods_preferences": {
-                "required": [
-                    "payment_flow",
-                    "commit",
-                    "intent",
-                    "vault",
-                    "payment_source_constraint"
-                ],
-                "properties": {
-                    "payment_flow": {
-                        "type": "string",
-                        "enum": [
-                            "ONE_TIME_PAYMENT"
-                        ]
-                    },
-                    "commit": {
-                        "type": "boolean"
-                    },
-                    "intent": {
-                        "type": "string",
-                        "enum": [
-                            "CAPTURE",
-                            "AUTHORIZE"
-                        ]
-                    },
-                    "vault": {
-                        "type": "boolean"
-                    },
-                    "payment_source_constraint": {
-                        "$ref": "#/components/schemas/paypal_v2_find_eligible_methods_preferences_payment_source_constraint"
-                    }
-                },
-                "type": "object"
-            },
-            "paypal_v2_order_shipping_callback": {
+            "paypal_v3_payment_token": {
                 "required": [
                     "id",
-                    "shipping_address",
-                    "shipping_option",
-                    "purchase_units"
+                    "status",
+                    "customer",
+                    "payment_source",
+                    "links",
+                    "metadata"
                 ],
                 "properties": {
                     "id": {
                         "type": "string"
                     },
-                    "shipping_address": {
-                        "$ref": "#/components/schemas/paypal_v2_common_address"
+                    "status": {
+                        "type": "string"
                     },
-                    "shipping_option": {
-                        "$ref": "#/components/schemas/paypal_v2_order_purchase_unit_shipping_option"
+                    "customer": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source_common_attributes_customer"
                     },
-                    "purchase_units": {
+                    "payment_source": {
+                        "$ref": "#/components/schemas/paypal_v2_order_payment_source"
+                    },
+                    "links": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/paypal_v2_order_purchase_unit"
+                            "$ref": "#/components/schemas/paypal_v2_common_link"
                         }
+                    },
+                    "metadata": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/paypal_v3_payment_token_metadata"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "paypal_v3_payment_token_metadata": {
+                "required": [
+                    "order_id"
+                ],
+                "properties": {
+                    "order_id": {
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/src/Resources/Schema/StoreApi/openapi.json
+++ b/src/Resources/Schema/StoreApi/openapi.json
@@ -4472,8 +4472,7 @@
                 ],
                 "properties": {
                     "liability_shift": {
-                        "type": "string",
-                        "nullable": true
+                        "type": "string"
                     },
                     "three_d_secure": {
                         "oneOf": [

--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -1595,7 +1595,7 @@ export interface components {
             stored_credential: components["schemas"]["paypal_v2_order_payment_source_card_stored_credential"] | null;
         };
         paypal_v2_order_payment_source_card_authentication_result: {
-            liability_shift: string | null;
+            liability_shift: string;
             three_d_secure: components["schemas"]["paypal_v2_order_payment_source_card_authentication_result_3d_secure"] | null;
         };
         paypal_v2_order_payment_source_card_authentication_result_3d_secure: {

--- a/src/Resources/app/administration/src/types/openapi.d.ts
+++ b/src/Resources/app/administration/src/types/openapi.d.ts
@@ -602,17 +602,6 @@ export interface components {
             liveCredentialsValid: boolean | null;
             webhookErrors: string[];
         };
-        paypal_v3_payment_token: {
-            id: string;
-            status: string;
-            customer: components["schemas"]["paypal_v2_order_payment_source_common_attributes_customer"];
-            payment_source: components["schemas"]["paypal_v2_order_payment_source"];
-            links: components["schemas"]["paypal_v2_common_link"][];
-            metadata: components["schemas"]["paypal_v3_payment_token_metadata"] | null;
-        };
-        paypal_v3_payment_token_metadata: {
-            order_id: string;
-        };
         paypal_error_detail: {
             field: string;
             value: string;
@@ -643,220 +632,111 @@ export interface components {
             update_time: string;
             links: components["schemas"]["paypal_v1_common_link"][];
         };
-        paypal_v1_merchant_integrations: {
-            merchant_id: string;
-            tracking_id: string;
-            products: components["schemas"]["paypal_v1_merchant_integrations_product"][];
-            capabilities: components["schemas"]["paypal_v1_merchant_integrations_capability"][] | null;
-            oauth_integrations: components["schemas"]["paypal_v1_merchant_integrations_oauth_integration"][];
-            granted_permissions: string[];
-            payments_receivable: boolean;
-            legal_name: string;
-            primary_email: string;
-            primary_email_confirmed: boolean;
+        paypal_v1_capture_transaction_fee: components["schemas"]["paypal_v1_common_value"];
+        paypal_v1_client_token: {
+            client_token: string;
+            /** @description The lifetime of the access token, in seconds. */
+            expires_in: number;
+            /**
+             * Format: date-time
+             * @description Calculated expiration date
+             */
+            expire_date_time: string;
         };
-        paypal_v1_refund: {
-            amount: components["schemas"]["paypal_v1_common_amount"];
-            invoice_number: string;
-            description: string;
-            reason: string;
-            id: string;
-            create_time: string;
-            update_time: string;
-            state: string;
-            refund_from_transaction_fee: components["schemas"]["paypal_v1_common_value"];
-            total_refunded_amount: components["schemas"]["paypal_v1_common_value"];
-            refund_from_received_amount: components["schemas"]["paypal_v1_common_value"];
-            sale_id: string;
-            capture_id: string;
-            parent_payment: string;
+        paypal_v1_common_address: {
+            line_1: string;
+            line_2: string | null;
+            city: string;
+            country_code: string;
+            postal_code: string;
+            state: string | null;
+            phone: string | null;
+        };
+        paypal_v1_common_amount: {
+            total: string;
+            currency: string;
+            details: components["schemas"]["paypal_v1_common_details"];
+        };
+        paypal_v1_common_details: {
+            subtotal: string;
+            shipping: string;
+            tax: string;
+            handling_fee: string;
+            shipping_discount: string;
+            discount: string;
+            insurance: string;
+        };
+        paypal_v1_common_link: {
+            href: string;
+            rel: string;
+            method: string;
+            enc_type: string | null;
+        };
+        paypal_v1_common_money: {
+            value: string;
+            currency_code: string;
+        };
+        paypal_v1_common_value: {
+            currency: string;
+            value: string;
+        };
+        paypal_v1_disputes: {
+            items: components["schemas"]["paypal_v1_disputes_item"][] | null;
             links: components["schemas"]["paypal_v1_common_link"][];
         };
-        paypal_v1_webhook_list: {
-            webhooks: components["schemas"]["paypal_v1_webhook"][];
-        };
-        paypal_v1_shipping_tracker: {
-            transaction_id: string;
-            tracking_number: string;
-            status: string;
-            carrier: string;
-            notify_buyer: boolean;
-            /** Format: date-time */
-            shipment_date: string;
-        };
-        paypal_v1_merchant_tracking: {
-            merchant_id: string;
-            tracking_id: string;
-            links: components["schemas"]["paypal_v1_common_link"][];
-        };
-        paypal_v1_plan_billing_cycle: {
-            frequency: components["schemas"]["paypal_v1_plan_billing_cycle_frequency"];
-            tenure_type: string;
-            sequence: number;
-            pricing_scheme: components["schemas"]["paypal_v1_plan_billing_cycle_pricing_scheme"];
-            total_cycles: number;
-        };
-        paypal_v1_plan_billing_cycle_frequency: {
-            interval_unit: string;
-            interval_count: number;
-        };
-        paypal_v1_plan_billing_cycle_pricing_scheme: {
-            fixed_price: components["schemas"]["paypal_v1_common_money"];
-        };
-        paypal_v1_plan_payment_preferences: {
-            auto_bill_outstanding: boolean;
-            payment_failure_threshold: number;
-        };
-        paypal_v1_plan_taxes: {
-            percentage: string;
-            inclusive: boolean;
-        };
-        paypal_v1_webhook: {
-            id: string;
-            url: string;
-            event_types: components["schemas"]["paypal_v1_webhook_event_type"][];
-            links: components["schemas"]["paypal_v1_common_link"][];
-        };
-        paypal_v1_disputes_item_refund_details: {
-            allowed_refund_amount: components["schemas"]["paypal_v1_common_money"];
-        };
-        paypal_v1_disputes_item_offer_history: {
-            offer_time: string;
-            actor: string;
-            event_type: string;
-            offer_type: string;
-        };
-        paypal_v1_disputes_item_extensions: {
-            merchant_contacted: boolean;
-            merchant_contacted_outcome: string;
-            merchant_contacted_time: string;
-            merchant_contacted_mode: string;
-            buyer_contacted_time: string;
-            buyer_contacted_channel: string;
-            billing_dispute_properties: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties"];
-            merchandize_dispute_properties: components["schemas"]["paypal_v1_disputes_item_extensions_merchandize_dispute_properties"];
-        };
-        paypal_v1_disputes_item_communication_details: {
-            email: string;
-            note: string;
-            time_posted: string;
-        };
-        paypal_v1_disputes_item_dispute_outcome: {
-            outcome_code: string;
-            amount_refunded: components["schemas"]["paypal_v1_common_money"];
-        };
-        paypal_v1_disputes_item_evidence_evidence_info_tracking_info: {
-            carrier_name: string;
-            carrier_name_other: string;
-            tracking_url: string;
-            tracking_number: string;
-        };
-        paypal_v1_disputes_item_evidence_evidence_info_refund_id: {
-            refund_id: string;
-        };
-        paypal_v1_disputes_item_evidence_evidence_info: {
-            tracking_info: components["schemas"]["paypal_v1_disputes_item_evidence_evidence_info_tracking_info"][];
-            refund_ids: components["schemas"]["paypal_v1_disputes_item_evidence_evidence_info_refund_id"][];
-        };
-        paypal_v1_disputes_item_evidence_document: {
+        paypal_v1_disputes_common_buyer: {
             name: string;
         };
-        paypal_v1_disputes_item_evidence: {
-            evidence_type: string;
-            evidence_info: components["schemas"]["paypal_v1_disputes_item_evidence_evidence_info"];
-            documents: components["schemas"]["paypal_v1_disputes_item_evidence_document"][];
-            notes: string;
+        paypal_v1_disputes_common_item: {
             item_id: string;
-        };
-        paypal_v1_disputes_item_disputed_transaction: components["schemas"]["paypal_v1_disputes_common_transaction"] & {
-            seller_protection_eligible: boolean;
-        };
-        paypal_v1_disputes_item_adjudication: {
-            type: string;
-            adjudication_time: string;
+            item_description: string;
+            item_quantity: string;
+            partner_transaction_id: string;
             reason: string;
-            dispute_life_cycle_stage: string;
-        };
-        paypal_v1_disputes_item_message: {
-            posted_by: string;
-            time_posted: string;
-            content: string;
-        };
-        paypal_v1_disputes_item_dispute_amount: components["schemas"]["paypal_v1_common_money"];
-        paypal_v1_disputes_item_extensions_merchandize_dispute_properties: {
-            issue_type: string;
-            product_details: components["schemas"]["paypal_v1_disputes_common_product_details"];
-            service_details: components["schemas"]["paypal_v1_disputes_common_service_details"];
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount: {
-            correct_transaction_amount: components["schemas"]["paypal_v1_common_money"];
-            correct_transaction_time: string;
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means: {
-            charge_different_from_original: boolean;
-            received_duplicate: boolean;
-            payment_method: string;
-            payment_instrument_suffix: string;
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing: {
-            expected_refund: components["schemas"]["paypal_v1_common_money"];
-            cancellation_details: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"];
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed: {
-            issue_type: string;
-            expected_refund: components["schemas"]["paypal_v1_common_money"];
-            cancellation_details: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"];
-            product_details: components["schemas"]["paypal_v1_disputes_common_product_details"];
-            service_details: components["schemas"]["paypal_v1_disputes_common_service_details"];
-            agreed_refund_details: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details"];
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details: {
-            merchant_agreed_refund: boolean;
-            merchant_agreed_refund_time: string;
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details: {
-            cancellation_date: string;
-            cancellation_number: string;
-            cancelled: boolean;
-            cancellation_mode: string;
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction: {
-            received_duplicate: boolean;
-            original_transaction: components["schemas"]["paypal_v1_disputes_common_transaction"];
-        };
-        paypal_v1_disputes_item_extensions_billing_dispute_properties: {
-            duplicate_transaction: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction"];
-            incorrect_transaction_amount: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount"];
-            payment_by_other_means: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means"];
-            credit_not_processed: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed"];
-            canceled_recurring_billing: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing"];
-        };
-        paypal_v1_disputes_item_partner_action: {
-            id: string;
-            name: string;
-            create_time: string;
-            update_time: string;
-            due_time: string;
-            status: string;
-            amount: components["schemas"]["paypal_v1_common_money"];
-        };
-        paypal_v1_disputes_item_offer: {
-            buyer_requested_amount: components["schemas"]["paypal_v1_common_money"];
-            seller_offered_amount: components["schemas"]["paypal_v1_common_money"];
-            offer_type: string;
-            history: components["schemas"]["paypal_v1_disputes_item_offer_history"][] | null;
-        };
-        paypal_v1_disputes_item_supporting_info: {
+            dispute_amount: components["schemas"]["paypal_v1_common_money"];
             notes: string;
-            source: string;
-            provided_time: string;
         };
-        paypal_v1_disputes_item_money_movement: {
-            affected_party: string;
-            amount: components["schemas"]["paypal_v1_common_amount"];
-            initiated_time: string;
-            type: string;
-            reason: string;
+        paypal_v1_disputes_common_product_details: {
+            product_received: string;
+            product_received_time: string;
+            sub_reasons: components["schemas"]["paypal_v1_disputes_common_sub_reason"][];
+            purchase_url: string;
+            return_details: components["schemas"]["paypal_v1_disputes_common_return_details"];
+        };
+        paypal_v1_disputes_common_return_details: {
+            return_time: string;
+            mode: string;
+            receipt: boolean;
+            return_confirmation_number: string;
+            returned: boolean;
+        };
+        paypal_v1_disputes_common_seller: {
+            email: string;
+            merchant_id: string;
+            name: string;
+        };
+        paypal_v1_disputes_common_service_details: {
+            description: string;
+            service_started: string;
+            note: string;
+            sub_reasons: components["schemas"]["paypal_v1_disputes_common_sub_reason"][];
+            purchase_url: string;
+        };
+        paypal_v1_disputes_common_sub_reason: {
+            sub_reason: string;
+        };
+        paypal_v1_disputes_common_transaction: {
+            buyer_transaction_id: string;
+            seller_transaction_id: string;
+            reference_id: string;
+            create_time: string;
+            transaction_status: string;
+            gross_amount: components["schemas"]["paypal_v1_common_money"];
+            invoice_number: string;
+            custom: string;
+            buyer: components["schemas"]["paypal_v1_disputes_common_buyer"];
+            seller: components["schemas"]["paypal_v1_disputes_common_seller"];
+            items: components["schemas"]["paypal_v1_disputes_common_item"][];
         };
         paypal_v1_disputes_item: {
             dispute_id: string;
@@ -886,132 +766,146 @@ export interface components {
             supporting_info: components["schemas"]["paypal_v1_disputes_item_supporting_info"][] | null;
             links: components["schemas"]["paypal_v1_common_link"][];
         };
-        paypal_v1_disputes_common_item: {
-            item_id: string;
-            item_description: string;
-            item_quantity: string;
-            partner_transaction_id: string;
+        paypal_v1_disputes_item_adjudication: {
+            type: string;
+            adjudication_time: string;
             reason: string;
-            dispute_amount: components["schemas"]["paypal_v1_common_money"];
-            notes: string;
+            dispute_life_cycle_stage: string;
         };
-        paypal_v1_disputes_common_transaction: {
-            buyer_transaction_id: string;
-            seller_transaction_id: string;
-            reference_id: string;
-            create_time: string;
-            transaction_status: string;
-            gross_amount: components["schemas"]["paypal_v1_common_money"];
-            invoice_number: string;
-            custom: string;
-            buyer: components["schemas"]["paypal_v1_disputes_common_buyer"];
-            seller: components["schemas"]["paypal_v1_disputes_common_seller"];
-            items: components["schemas"]["paypal_v1_disputes_common_item"][];
-        };
-        paypal_v1_disputes_common_product_details: {
-            product_received: string;
-            product_received_time: string;
-            sub_reasons: components["schemas"]["paypal_v1_disputes_common_sub_reason"][];
-            purchase_url: string;
-            return_details: components["schemas"]["paypal_v1_disputes_common_return_details"];
-        };
-        paypal_v1_disputes_common_seller: {
+        paypal_v1_disputes_item_communication_details: {
             email: string;
-            merchant_id: string;
-            name: string;
-        };
-        paypal_v1_disputes_common_sub_reason: {
-            sub_reason: string;
-        };
-        paypal_v1_disputes_common_service_details: {
-            description: string;
-            service_started: string;
             note: string;
-            sub_reasons: components["schemas"]["paypal_v1_disputes_common_sub_reason"][];
-            purchase_url: string;
+            time_posted: string;
         };
-        paypal_v1_disputes_common_return_details: {
-            return_time: string;
-            mode: string;
-            receipt: boolean;
-            return_confirmation_number: string;
-            returned: boolean;
+        paypal_v1_disputes_item_dispute_amount: components["schemas"]["paypal_v1_common_money"];
+        paypal_v1_disputes_item_dispute_outcome: {
+            outcome_code: string;
+            amount_refunded: components["schemas"]["paypal_v1_common_money"];
         };
-        paypal_v1_disputes_common_buyer: {
+        paypal_v1_disputes_item_disputed_transaction: components["schemas"]["paypal_v1_disputes_common_transaction"] & {
+            seller_protection_eligible: boolean;
+        };
+        paypal_v1_disputes_item_evidence: {
+            evidence_type: string;
+            evidence_info: components["schemas"]["paypal_v1_disputes_item_evidence_evidence_info"];
+            documents: components["schemas"]["paypal_v1_disputes_item_evidence_document"][];
+            notes: string;
+            item_id: string;
+        };
+        paypal_v1_disputes_item_evidence_document: {
             name: string;
         };
-        paypal_v1_webhook_event_type: {
-            name: string;
-            description: string;
-            status: string;
-            resource_version: string;
+        paypal_v1_disputes_item_evidence_evidence_info: {
+            tracking_info: components["schemas"]["paypal_v1_disputes_item_evidence_evidence_info_tracking_info"][];
+            refund_ids: components["schemas"]["paypal_v1_disputes_item_evidence_evidence_info_refund_id"][];
         };
-        paypal_v1_webhook_event: {
-            id: string;
-            resource_type: string;
-            event_type: string;
-            summary: string;
-            resource: (components["schemas"]["paypal_v3_payment_token"] | components["schemas"]["paypal_v2_order_purchase_unit_payments_authorization"] | components["schemas"]["paypal_v2_order_purchase_unit_payments_capture"] | components["schemas"]["paypal_v2_order_purchase_unit_payments_refund"] | components["schemas"]["paypal_v1_webhook_resource"] | components["schemas"]["paypal_v1_subscription"]) | null;
-            create_time: string;
-            links: components["schemas"]["paypal_v1_common_link"][];
-            event_version: string;
-            resource_version: string;
+        paypal_v1_disputes_item_evidence_evidence_info_refund_id: {
+            refund_id: string;
         };
-        paypal_v1_webhook_resource: {
-            id: string;
-            parent_payment: string | null;
-            billing_agreement_id: string | null;
-            sale_id: string | null;
-            refund_reason_code: string | null;
-            update_time: string;
+        paypal_v1_disputes_item_evidence_evidence_info_tracking_info: {
+            carrier_name: string;
+            carrier_name_other: string;
+            tracking_url: string;
+            tracking_number: string;
+        };
+        paypal_v1_disputes_item_extensions: {
+            merchant_contacted: boolean;
+            merchant_contacted_outcome: string;
+            merchant_contacted_time: string;
+            merchant_contacted_mode: string;
+            buyer_contacted_time: string;
+            buyer_contacted_channel: string;
+            billing_dispute_properties: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties"];
+            merchandize_dispute_properties: components["schemas"]["paypal_v1_disputes_item_extensions_merchandize_dispute_properties"];
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties: {
+            duplicate_transaction: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction"];
+            incorrect_transaction_amount: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount"];
+            payment_by_other_means: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means"];
+            credit_not_processed: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed"];
+            canceled_recurring_billing: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing"];
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties_canceled_recurring_billing: {
+            expected_refund: components["schemas"]["paypal_v1_common_money"];
+            cancellation_details: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"];
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details: {
+            merchant_agreed_refund: boolean;
+            merchant_agreed_refund_time: string;
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details: {
+            cancellation_date: string;
+            cancellation_number: string;
+            cancelled: boolean;
+            cancellation_mode: string;
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties_credit_not_processed: {
+            issue_type: string;
+            expected_refund: components["schemas"]["paypal_v1_common_money"];
+            cancellation_details: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_common_cancellation_details"];
+            product_details: components["schemas"]["paypal_v1_disputes_common_product_details"];
+            service_details: components["schemas"]["paypal_v1_disputes_common_service_details"];
+            agreed_refund_details: components["schemas"]["paypal_v1_disputes_item_extensions_billing_dispute_properties_common_agreed_refund_details"];
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties_duplicate_transaction: {
+            received_duplicate: boolean;
+            original_transaction: components["schemas"]["paypal_v1_disputes_common_transaction"];
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties_incorrect_transaction_amount: {
+            correct_transaction_amount: components["schemas"]["paypal_v1_common_money"];
+            correct_transaction_time: string;
+        };
+        paypal_v1_disputes_item_extensions_billing_dispute_properties_payment_by_other_means: {
+            charge_different_from_original: boolean;
+            received_duplicate: boolean;
+            payment_method: string;
+            payment_instrument_suffix: string;
+        };
+        paypal_v1_disputes_item_extensions_merchandize_dispute_properties: {
+            issue_type: string;
+            product_details: components["schemas"]["paypal_v1_disputes_common_product_details"];
+            service_details: components["schemas"]["paypal_v1_disputes_common_service_details"];
+        };
+        paypal_v1_disputes_item_message: {
+            posted_by: string;
+            time_posted: string;
+            content: string;
+        };
+        paypal_v1_disputes_item_money_movement: {
+            affected_party: string;
             amount: components["schemas"]["paypal_v1_common_amount"];
-            payment_mode: string;
+            initiated_time: string;
+            type: string;
+            reason: string;
+        };
+        paypal_v1_disputes_item_offer: {
+            buyer_requested_amount: components["schemas"]["paypal_v1_common_money"];
+            seller_offered_amount: components["schemas"]["paypal_v1_common_money"];
+            offer_type: string;
+            history: components["schemas"]["paypal_v1_disputes_item_offer_history"][] | null;
+        };
+        paypal_v1_disputes_item_offer_history: {
+            offer_time: string;
+            actor: string;
+            event_type: string;
+            offer_type: string;
+        };
+        paypal_v1_disputes_item_partner_action: {
+            id: string;
+            name: string;
             create_time: string;
-            clearing_time: string;
-            protection_eligibility_type: string;
-            protection_eligibility: string;
-            transaction_fee: components["schemas"]["paypal_v1_common_value"];
-            invoice_number: string;
-            links: components["schemas"]["paypal_v1_common_link"][];
-            state: string;
-            merchant_id: string | null;
+            update_time: string;
+            due_time: string;
+            status: string;
+            amount: components["schemas"]["paypal_v1_common_money"];
         };
-        paypal_v1_token: {
-            /**
-             * @description Scopes expressed in the form of resource URL endpoints. The value of the scope parameter
-             *     is expressed as a list of space-delimited, case-sensitive strings.
-             */
-            scope: string;
-            nonce: string;
-            /**
-             * @description The access token issued by PayPal. After the access token
-             *     expires (see $expiresIn), you must request a new access token.
-             */
-            access_token: string;
-            /**
-             * @description The type of the token issued as described in OAuth2.0 RFC6749,
-             *     Section 7.1. Value is case insensitive.
-             */
-            token_type: string;
-            app_id: string;
-            id_token: string | null;
-            /** @description The lifetime of the access token, in seconds. */
-            expires_in: number;
-            /**
-             * Format: date-time
-             * @description Calculated expiration date
-             */
-            expire_date_time: string;
+        paypal_v1_disputes_item_refund_details: {
+            allowed_refund_amount: components["schemas"]["paypal_v1_common_money"];
         };
-        paypal_v1_client_token: {
-            client_token: string;
-            /** @description The lifetime of the access token, in seconds. */
-            expires_in: number;
-            /**
-             * Format: date-time
-             * @description Calculated expiration date
-             */
-            expire_date_time: string;
+        paypal_v1_disputes_item_supporting_info: {
+            notes: string;
+            source: string;
+            provided_time: string;
         };
         paypal_v1_do_void: {
             id: string;
@@ -1022,42 +916,73 @@ export interface components {
             update_time: string;
             links: components["schemas"]["paypal_v1_common_link"][];
         };
-        paypal_v1_common_value: {
-            currency: string;
-            value: string;
+        paypal_v1_merchant_integrations: {
+            merchant_id: string;
+            tracking_id: string;
+            products: components["schemas"]["paypal_v1_merchant_integrations_product"][];
+            capabilities: components["schemas"]["paypal_v1_merchant_integrations_capability"][] | null;
+            oauth_integrations: components["schemas"]["paypal_v1_merchant_integrations_oauth_integration"][];
+            granted_permissions: string[];
+            payments_receivable: boolean;
+            legal_name: string;
+            primary_email: string;
+            primary_email_confirmed: boolean;
         };
-        paypal_v1_common_link: {
-            href: string;
-            rel: string;
-            method: string;
-            enc_type: string | null;
+        paypal_v1_merchant_integrations_capability: {
+            name: string;
+            status: string;
         };
-        paypal_v1_common_details: {
-            subtotal: string;
-            shipping: string;
-            tax: string;
-            handling_fee: string;
-            shipping_discount: string;
-            discount: string;
-            insurance: string;
+        paypal_v1_merchant_integrations_credentials: {
+            client_id: string;
+            client_secret: string;
+            payer_id: string;
         };
-        paypal_v1_common_amount: {
-            total: string;
-            currency: string;
-            details: components["schemas"]["paypal_v1_common_details"];
+        paypal_v1_merchant_integrations_oauth_integration: {
+            integration_method?: string;
+            integration_type?: string;
+            status?: string;
+            oauth_third_party?: components["schemas"]["paypal_v1_merchant_integrations_oauth_integration_oauth_third_party"][];
         };
-        paypal_v1_common_address: {
-            line_1: string;
-            line_2: string | null;
-            city: string;
-            country_code: string;
-            postal_code: string;
-            state: string | null;
-            phone: string | null;
+        paypal_v1_merchant_integrations_oauth_integration_oauth_third_party: {
+            access_token?: string;
+            merchant_client_id?: string;
+            partner_client_id?: string;
+            refresh_token?: string;
+            scopes: string[];
         };
-        paypal_v1_common_money: {
-            value: string;
-            currency_code: string;
+        paypal_v1_merchant_integrations_product: {
+            name: string;
+            vetting_status?: string;
+            capabilities?: string[];
+        };
+        paypal_v1_merchant_tracking: {
+            merchant_id: string;
+            tracking_id: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
+        };
+        paypal_v1_patch: {
+            /** @enum {string} */
+            op: "add" | "replace";
+            path: string;
+            value: string | Record<string, unknown>[];
+        };
+        paypal_v1_payment: {
+            id: string;
+            /**
+             * @default sale
+             * @enum {string}
+             */
+            intent: "sale" | "authorize" | "order";
+            state: string;
+            cart: string;
+            payer: components["schemas"]["paypal_v1_payment_payer"];
+            transactions: components["schemas"]["paypal_v1_payment_transaction"][];
+            create_time: string;
+            update_time: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
+            redirect_urls: components["schemas"]["paypal_v1_payment_redirect_urls"];
+            application_context: components["schemas"]["paypal_v1_payment_application_context"];
+            payment_instruction: components["schemas"]["paypal_v1_payment_payment_instruction"] | null;
         };
         paypal_v1_payment_application_context: {
             brand_name: string;
@@ -1069,6 +994,42 @@ export interface components {
             /** @default commit */
             user_action: string;
         };
+        paypal_v1_payment_payer: {
+            payment_method: string;
+            status: string;
+            payer_info: components["schemas"]["paypal_v1_payment_payer_payer_info"];
+            external_selected_funding_instrument_type: string;
+        };
+        paypal_v1_payment_payer_execute_payer_info: {
+            payer_id: string;
+        };
+        paypal_v1_payment_payer_payer_info: components["schemas"]["paypal_v1_payment_payer_execute_payer_info"] & {
+            email: string;
+            first_name: string;
+            last_name: string;
+            billing_address: components["schemas"]["paypal_v1_common_address"] | null;
+            shipping_address: components["schemas"]["paypal_v1_payment_transaction_item_list_shipping_address"];
+            phone: string;
+            country_code: string;
+        };
+        paypal_v1_payment_payment_instruction: {
+            reference_number: string;
+            recipient_banking_instruction: components["schemas"]["paypal_v1_payment_payment_instruction_recipient_banking_instruction"];
+            amount: components["schemas"]["paypal_v1_common_value"];
+            payment_due_date: string;
+            instruction_type: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
+        };
+        paypal_v1_payment_payment_instruction_recipient_banking_instruction: {
+            bank_name: string;
+            account_holder_name: string;
+            international_bank_account_number: string;
+            bank_identifier_code: string;
+        };
+        paypal_v1_payment_redirect_urls: {
+            return_url: string;
+            cancel_url: string;
+        };
         paypal_v1_payment_transaction: {
             amount: components["schemas"]["paypal_v1_common_amount"];
             payee: components["schemas"]["paypal_v1_payment_transaction_payee"];
@@ -1079,17 +1040,49 @@ export interface components {
             description: string;
             custom: string;
         };
-        paypal_v1_payment_payment_instruction: {
-            reference_number: string;
-            recipient_banking_instruction: components["schemas"]["paypal_v1_payment_payment_instruction_recipient_banking_instruction"];
-            amount: components["schemas"]["paypal_v1_common_value"];
-            payment_due_date: string;
-            instruction_type: string;
-            links: components["schemas"]["paypal_v1_common_link"][];
+        paypal_v1_payment_transaction_item_list: {
+            shipping_address: components["schemas"]["paypal_v1_payment_transaction_item_list_shipping_address"];
+            items: components["schemas"]["paypal_v1_payment_transaction_item_list_item"][];
+            shipping_options: components["schemas"]["paypal_v1_payment_transaction_item_list_shipping_option"][];
+            shipping_phone_number: string;
         };
+        paypal_v1_payment_transaction_item_list_item: {
+            name: string;
+            currency: string;
+            price: string;
+            quantity: number;
+            sku: string | null;
+            tax: string;
+        };
+        paypal_v1_payment_transaction_item_list_shipping_address: components["schemas"]["paypal_v1_common_address"] & {
+            recipient_name: string;
+        };
+        paypal_v1_payment_transaction_item_list_shipping_option: Record<string, unknown>;
         paypal_v1_payment_transaction_payee: {
             merchant_id: string;
             email: string;
+        };
+        paypal_v1_payment_transaction_related_resource: {
+            sale: components["schemas"]["paypal_v1_payment_transaction_related_resource_sale"] | null;
+            authorization: components["schemas"]["paypal_v1_payment_transaction_related_resource_authorization"] | null;
+            order: components["schemas"]["paypal_v1_payment_transaction_related_resource_order"] | null;
+            refund: components["schemas"]["paypal_v1_payment_transaction_related_resource_refund"] | null;
+            capture: components["schemas"]["paypal_v1_payment_transaction_related_resource_capture"] | null;
+        };
+        paypal_v1_payment_transaction_related_resource_authorization: {
+            id: string;
+            state: string;
+            amount: components["schemas"]["paypal_v1_common_amount"];
+            payment_mode: string;
+            create_time: string;
+            update_time: string;
+            protection_eligibility: string;
+            protection_eligibility_type: string;
+            receipt_id: string;
+            parent_payment: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
+            reason_code: string;
+            valid_until: string;
         };
         paypal_v1_payment_transaction_related_resource_capture: {
             id: string;
@@ -1106,6 +1099,20 @@ export interface components {
             custom: string;
             transaction_fee: components["schemas"]["paypal_v1_common_value"];
             invoice_number: string;
+        };
+        paypal_v1_payment_transaction_related_resource_order: {
+            id: string;
+            state: string;
+            amount: components["schemas"]["paypal_v1_common_amount"];
+            payment_mode: string;
+            create_time: string;
+            update_time: string;
+            protection_eligibility: string;
+            protection_eligibility_type: string;
+            receipt_id: string;
+            parent_payment: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
+            reason_code: string;
         };
         paypal_v1_payment_transaction_related_resource_refund: {
             id: string;
@@ -1136,153 +1143,6 @@ export interface components {
             links: components["schemas"]["paypal_v1_common_link"][];
             transaction_fee: components["schemas"]["paypal_v1_common_value"];
         };
-        paypal_v1_payment_transaction_related_resource_order: {
-            id: string;
-            state: string;
-            amount: components["schemas"]["paypal_v1_common_amount"];
-            payment_mode: string;
-            create_time: string;
-            update_time: string;
-            protection_eligibility: string;
-            protection_eligibility_type: string;
-            receipt_id: string;
-            parent_payment: string;
-            links: components["schemas"]["paypal_v1_common_link"][];
-            reason_code: string;
-        };
-        paypal_v1_payment_transaction_related_resource_authorization: {
-            id: string;
-            state: string;
-            amount: components["schemas"]["paypal_v1_common_amount"];
-            payment_mode: string;
-            create_time: string;
-            update_time: string;
-            protection_eligibility: string;
-            protection_eligibility_type: string;
-            receipt_id: string;
-            parent_payment: string;
-            links: components["schemas"]["paypal_v1_common_link"][];
-            reason_code: string;
-            valid_until: string;
-        };
-        paypal_v1_payment_transaction_item_list: {
-            shipping_address: components["schemas"]["paypal_v1_payment_transaction_item_list_shipping_address"];
-            items: components["schemas"]["paypal_v1_payment_transaction_item_list_item"][];
-            shipping_options: components["schemas"]["paypal_v1_payment_transaction_item_list_shipping_option"][];
-            shipping_phone_number: string;
-        };
-        paypal_v1_payment_transaction_item_list_item: {
-            name: string;
-            currency: string;
-            price: string;
-            quantity: number;
-            sku: string | null;
-            tax: string;
-        };
-        paypal_v1_payment_transaction_item_list_shipping_option: Record<string, unknown>;
-        paypal_v1_payment_transaction_item_list_shipping_address: components["schemas"]["paypal_v1_common_address"] & {
-            recipient_name: string;
-        };
-        paypal_v1_payment_transaction_related_resource: {
-            sale: components["schemas"]["paypal_v1_payment_transaction_related_resource_sale"] | null;
-            authorization: components["schemas"]["paypal_v1_payment_transaction_related_resource_authorization"] | null;
-            order: components["schemas"]["paypal_v1_payment_transaction_related_resource_order"] | null;
-            refund: components["schemas"]["paypal_v1_payment_transaction_related_resource_refund"] | null;
-            capture: components["schemas"]["paypal_v1_payment_transaction_related_resource_capture"] | null;
-        };
-        paypal_v1_payment_payer_execute_payer_info: {
-            payer_id: string;
-        };
-        paypal_v1_payment_payer_payer_info: components["schemas"]["paypal_v1_payment_payer_execute_payer_info"] & {
-            email: string;
-            first_name: string;
-            last_name: string;
-            billing_address: components["schemas"]["paypal_v1_common_address"] | null;
-            shipping_address: components["schemas"]["paypal_v1_payment_transaction_item_list_shipping_address"];
-            phone: string;
-            country_code: string;
-        };
-        paypal_v1_payment_redirect_urls: {
-            return_url: string;
-            cancel_url: string;
-        };
-        paypal_v1_payment_payer: {
-            payment_method: string;
-            status: string;
-            payer_info: components["schemas"]["paypal_v1_payment_payer_payer_info"];
-            external_selected_funding_instrument_type: string;
-        };
-        paypal_v1_payment_payment_instruction_recipient_banking_instruction: {
-            bank_name: string;
-            account_holder_name: string;
-            international_bank_account_number: string;
-            bank_identifier_code: string;
-        };
-        paypal_v1_patch: {
-            /** @enum {string} */
-            op: "add" | "replace";
-            path: string;
-            value: string | Record<string, unknown>[];
-        };
-        paypal_v1_product: {
-            name: string;
-            description: string;
-            type: string;
-        };
-        paypal_v1_subscription_application_context: {
-            /** @default SUBSCRIBE_NOW */
-            user_action: string;
-            brand_name: string;
-            locale: string;
-            /** @default SET_PROVIDED_ADDRESS */
-            shipping_preference: string;
-            return_url: string;
-            cancel_url: string;
-        };
-        paypal_v1_subscription_billing_info_cycle_execution: {
-            tenure_type: string;
-            sequence: number;
-            cycles_completed: number;
-            cycles_remaining: number;
-            total_cycles: number;
-        };
-        paypal_v1_subscription_billing_info_outstanding_balance: components["schemas"]["paypal_v1_common_money"];
-        paypal_v1_subscription_billing_info_last_payment: {
-            amount: components["schemas"]["paypal_v1_common_money"];
-            time: string;
-        };
-        paypal_v1_subscription_billing_info: {
-            outstanding_balance: components["schemas"]["paypal_v1_subscription_billing_info_outstanding_balance"];
-            cycle_executions: components["schemas"]["paypal_v1_subscription_billing_info_cycle_execution"][];
-            last_payment: components["schemas"]["paypal_v1_subscription_billing_info_last_payment"];
-            next_billing_time: string | null;
-            failed_payments_count: number;
-        };
-        paypal_v1_subscription_subscriber_name: {
-            given_name: string;
-            surname: string;
-        };
-        paypal_v1_subscription_subscriber_shipping_address_name: {
-            full_name: string;
-        };
-        paypal_v1_subscription_subscriber_shipping_address_address: {
-            address_line_1: string | null;
-            address_line_2: string | null;
-            admin_area_1: string | null;
-            admin_area_2: string | null;
-            postal_code: string | null;
-            country_code: string;
-        };
-        paypal_v1_subscription_subscriber_shipping_address: {
-            name: components["schemas"]["paypal_v1_subscription_subscriber_shipping_address_name"] | null;
-            address: components["schemas"]["paypal_v1_subscription_subscriber_shipping_address_address"] | null;
-        };
-        paypal_v1_subscription_subscriber: {
-            name: components["schemas"]["paypal_v1_subscription_subscriber_name"];
-            email_address: string;
-            payer_id: string;
-            shipping_address: components["schemas"]["paypal_v1_subscription_subscriber_shipping_address"] | null;
-        };
         paypal_v1_plan: {
             product_id: string;
             name: string;
@@ -1292,8 +1152,61 @@ export interface components {
             payment_preferences: components["schemas"]["paypal_v1_plan_payment_preferences"];
             taxes: components["schemas"]["paypal_v1_plan_taxes"];
         };
+        paypal_v1_plan_billing_cycle: {
+            frequency: components["schemas"]["paypal_v1_plan_billing_cycle_frequency"];
+            tenure_type: string;
+            sequence: number;
+            pricing_scheme: components["schemas"]["paypal_v1_plan_billing_cycle_pricing_scheme"];
+            total_cycles: number;
+        };
+        paypal_v1_plan_billing_cycle_frequency: {
+            interval_unit: string;
+            interval_count: number;
+        };
+        paypal_v1_plan_billing_cycle_pricing_scheme: {
+            fixed_price: components["schemas"]["paypal_v1_common_money"];
+        };
+        paypal_v1_plan_payment_preferences: {
+            auto_bill_outstanding: boolean;
+            payment_failure_threshold: number;
+        };
+        paypal_v1_plan_taxes: {
+            percentage: string;
+            inclusive: boolean;
+        };
+        paypal_v1_product: {
+            name: string;
+            description: string;
+            type: string;
+        };
+        paypal_v1_refund: {
+            amount: components["schemas"]["paypal_v1_common_amount"];
+            invoice_number: string;
+            description: string;
+            reason: string;
+            id: string;
+            create_time: string;
+            update_time: string;
+            state: string;
+            refund_from_transaction_fee: components["schemas"]["paypal_v1_common_value"];
+            total_refunded_amount: components["schemas"]["paypal_v1_common_value"];
+            refund_from_received_amount: components["schemas"]["paypal_v1_common_value"];
+            sale_id: string;
+            capture_id: string;
+            parent_payment: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
+        };
         paypal_v1_shipping: {
             trackers: components["schemas"]["paypal_v1_shipping_tracker"][];
+        };
+        paypal_v1_shipping_tracker: {
+            transaction_id: string;
+            tracking_number: string;
+            status: string;
+            carrier: string;
+            notify_buyer: boolean;
+            /** Format: date-time */
+            shipment_date: string;
         };
         paypal_v1_subscription: {
             id: string;
@@ -1310,67 +1223,274 @@ export interface components {
             update_time: string;
             links: components["schemas"]["paypal_v1_common_link"][];
         };
-        paypal_v1_disputes: {
-            items: components["schemas"]["paypal_v1_disputes_item"][] | null;
+        paypal_v1_subscription_application_context: {
+            /** @default SUBSCRIBE_NOW */
+            user_action: string;
+            brand_name: string;
+            locale: string;
+            /** @default SET_PROVIDED_ADDRESS */
+            shipping_preference: string;
+            return_url: string;
+            cancel_url: string;
+        };
+        paypal_v1_subscription_billing_info: {
+            outstanding_balance: components["schemas"]["paypal_v1_subscription_billing_info_outstanding_balance"];
+            cycle_executions: components["schemas"]["paypal_v1_subscription_billing_info_cycle_execution"][];
+            last_payment: components["schemas"]["paypal_v1_subscription_billing_info_last_payment"];
+            next_billing_time: string | null;
+            failed_payments_count: number;
+        };
+        paypal_v1_subscription_billing_info_cycle_execution: {
+            tenure_type: string;
+            sequence: number;
+            cycles_completed: number;
+            cycles_remaining: number;
+            total_cycles: number;
+        };
+        paypal_v1_subscription_billing_info_last_payment: {
+            amount: components["schemas"]["paypal_v1_common_money"];
+            time: string;
+        };
+        paypal_v1_subscription_billing_info_outstanding_balance: components["schemas"]["paypal_v1_common_money"];
+        paypal_v1_subscription_subscriber: {
+            name: components["schemas"]["paypal_v1_subscription_subscriber_name"];
+            email_address: string;
+            payer_id: string;
+            shipping_address: components["schemas"]["paypal_v1_subscription_subscriber_shipping_address"] | null;
+        };
+        paypal_v1_subscription_subscriber_name: {
+            given_name: string;
+            surname: string;
+        };
+        paypal_v1_subscription_subscriber_shipping_address: {
+            name: components["schemas"]["paypal_v1_subscription_subscriber_shipping_address_name"] | null;
+            address: components["schemas"]["paypal_v1_subscription_subscriber_shipping_address_address"] | null;
+        };
+        paypal_v1_subscription_subscriber_shipping_address_address: {
+            address_line_1: string | null;
+            address_line_2: string | null;
+            admin_area_1: string | null;
+            admin_area_2: string | null;
+            postal_code: string | null;
+            country_code: string;
+        };
+        paypal_v1_subscription_subscriber_shipping_address_name: {
+            full_name: string;
+        };
+        paypal_v1_token: {
+            /**
+             * @description Scopes expressed in the form of resource URL endpoints. The value of the scope parameter
+             *     is expressed as a list of space-delimited, case-sensitive strings.
+             */
+            scope: string;
+            nonce: string;
+            /**
+             * @description The access token issued by PayPal. After the access token
+             *     expires (see $expiresIn), you must request a new access token.
+             */
+            access_token: string;
+            /**
+             * @description The type of the token issued as described in OAuth2.0 RFC6749,
+             *     Section 7.1. Value is case insensitive.
+             */
+            token_type: string;
+            app_id: string;
+            id_token: string | null;
+            /** @description The lifetime of the access token, in seconds. */
+            expires_in: number;
+            /**
+             * Format: date-time
+             * @description Calculated expiration date
+             */
+            expire_date_time: string;
+        };
+        paypal_v1_webhook: {
+            id: string;
+            url: string;
+            event_types: components["schemas"]["paypal_v1_webhook_event_type"][];
             links: components["schemas"]["paypal_v1_common_link"][];
         };
-        paypal_v1_capture_transaction_fee: components["schemas"]["paypal_v1_common_value"];
-        paypal_v1_merchant_integrations_oauth_integration: {
-            integration_method?: string;
-            integration_type?: string;
-            status?: string;
-            oauth_third_party?: components["schemas"]["paypal_v1_merchant_integrations_oauth_integration_oauth_third_party"][];
-        };
-        paypal_v1_merchant_integrations_oauth_integration_oauth_third_party: {
-            access_token?: string;
-            merchant_client_id?: string;
-            partner_client_id?: string;
-            refresh_token?: string;
-            scopes: string[];
-        };
-        paypal_v1_merchant_integrations_credentials: {
-            client_id: string;
-            client_secret: string;
-            payer_id: string;
-        };
-        paypal_v1_merchant_integrations_capability: {
-            name: string;
-            status: string;
-        };
-        paypal_v1_merchant_integrations_product: {
-            name: string;
-            vetting_status?: string;
-            capabilities?: string[];
-        };
-        paypal_v1_payment: {
+        paypal_v1_webhook_event: {
             id: string;
-            /**
-             * @default sale
-             * @enum {string}
-             */
-            intent: "sale" | "authorize" | "order";
+            resource_type: string;
+            event_type: string;
+            summary: string;
+            resource: (components["schemas"]["paypal_v3_payment_token"] | components["schemas"]["paypal_v2_order_purchase_unit_payments_authorization"] | components["schemas"]["paypal_v2_order_purchase_unit_payments_capture"] | components["schemas"]["paypal_v2_order_purchase_unit_payments_refund"] | components["schemas"]["paypal_v1_webhook_resource"] | components["schemas"]["paypal_v1_subscription"]) | null;
+            create_time: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
+            event_version: string;
+            resource_version: string;
+        };
+        paypal_v1_webhook_event_type: {
+            name: string;
+            description: string;
+            status: string;
+            resource_version: string;
+        };
+        paypal_v1_webhook_resource: {
+            id: string;
+            parent_payment: string | null;
+            billing_agreement_id: string | null;
+            sale_id: string | null;
+            refund_reason_code: string | null;
+            update_time: string;
+            amount: components["schemas"]["paypal_v1_common_amount"];
+            payment_mode: string;
+            create_time: string;
+            clearing_time: string;
+            protection_eligibility_type: string;
+            protection_eligibility: string;
+            transaction_fee: components["schemas"]["paypal_v1_common_value"];
+            invoice_number: string;
+            links: components["schemas"]["paypal_v1_common_link"][];
             state: string;
-            cart: string;
-            payer: components["schemas"]["paypal_v1_payment_payer"];
-            transactions: components["schemas"]["paypal_v1_payment_transaction"][];
+            merchant_id: string | null;
+        };
+        paypal_v1_webhook_list: {
+            webhooks: components["schemas"]["paypal_v1_webhook"][];
+        };
+        paypal_v2_common_address: {
+            /**
+             * @description The first line of the address. For example, number or street. For example, 173 Drury Lane.
+             *     Required for data entry and compliance and risk checks. Must contain the full address.
+             */
+            address_line_1: string | null;
+            /** @description The second line of the address. For example, suite or apartment number. */
+            address_line_2: string | null;
+            /** @description A city, town, or village. Smaller than $adminArea1 */
+            admin_area_2: string | null;
+            /**
+             * @description The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.
+             *     Format for postal delivery. For example, CA and not California.
+             */
+            admin_area_1: string | null;
+            postal_code: string | null;
+            country_code: string;
+        };
+        paypal_v2_common_link: {
+            href: string;
+            rel: string;
+            method: string;
+            enc_type: string | null;
+        };
+        paypal_v2_common_money: {
+            currency_code: string;
+            value: string;
+        };
+        paypal_v2_common_name: {
+            given_name: string;
+            surname: string;
+        };
+        paypal_v2_common_phone_number: {
+            national_number: string;
+            country_code: string;
+        };
+        paypal_v2_common_upc: {
+            type: string;
+            code: string;
+        };
+        paypal_v2_confirm_order: {
+            payment_source: components["schemas"]["paypal_v2_order_payment_source"];
+        };
+        paypal_v2_eligible_methods_data: {
+            eligible_methods: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods"];
+            supplementary_data: components["schemas"]["paypal_v2_eligible_methods_data_supplementary_data"];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods: {
+            paypal: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"];
+            paypal_pay_later: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"];
+            apple_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_apple_pay"];
+            google_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_google_pay"];
+            advanced_cards: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"];
+            eps: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_eps"];
+            p_2_4: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_p24"];
+            blik: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_blik"];
+            ideal: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_ideal"];
+            bizum: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_bizum"];
+            bancontact: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_bancontact"];
+            klarna: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_klarna"];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_advanced_cards: {
+            supports_installements: boolean;
+            cobranded_enabled: boolean;
+            vendors: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"][];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            eligible: boolean;
+            network: string;
+            branded: boolean;
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_apple_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            config: Record<string, unknown>[];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_bancontact: Record<string, unknown>;
+        paypal_v2_eligible_methods_data_eligible_methods_bizum: Record<string, unknown>;
+        paypal_v2_eligible_methods_data_eligible_methods_blik: Record<string, unknown>;
+        paypal_v2_eligible_methods_data_eligible_methods_eps: Record<string, unknown>;
+        paypal_v2_eligible_methods_data_eligible_methods_google_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            config: Record<string, unknown>[];
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_ideal: Record<string, unknown>;
+        paypal_v2_eligible_methods_data_eligible_methods_klarna: Record<string, unknown>;
+        paypal_v2_eligible_methods_data_eligible_methods_p24: Record<string, unknown>;
+        paypal_v2_eligible_methods_data_eligible_methods_paypal: {
+            can_be_vaulted: boolean;
+        };
+        paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
+            /** @description ISO 3166-1 alpha-2 country code */
+            country_code: string;
+            product_code: string;
+        };
+        paypal_v2_eligible_methods_data_supplementary_data: {
+            /** @description ISO 3166-1 alpha-2 country code */
+            buyer_country_code: string;
+        };
+        paypal_v2_find_eligible_methods: {
+            customer: components["schemas"]["paypal_v2_find_eligible_methods_customer"];
+            preferences: components["schemas"]["paypal_v2_find_eligible_methods_preferences"];
+            /**
+             * @description Does not have to be a full purchase unit.
+             *     `[{"amount":{"currency_code":"<iso-4217-code>"},"payee":{"merchant_id":"<merchant-id>"}}]` is enough.
+             */
+            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][];
+        };
+        paypal_v2_find_eligible_methods_customer: {
+            /** @description ISO 3166-1 alpha-2 country code */
+            country_code: string;
+            channel: components["schemas"]["paypal_v2_find_eligible_methods_customer_channel"];
+        };
+        paypal_v2_find_eligible_methods_customer_channel: {
+            browser_type: string | null;
+            client_os: string | null;
+            device_type: string | null;
+        };
+        paypal_v2_find_eligible_methods_preferences: {
+            /** @enum {string} */
+            payment_flow: "ONE_TIME_PAYMENT";
+            commit: boolean;
+            /** @enum {string} */
+            intent: "CAPTURE" | "AUTHORIZE";
+            vault: boolean;
+            payment_source_constraint: components["schemas"]["paypal_v2_find_eligible_methods_preferences_payment_source_constraint"];
+        };
+        paypal_v2_find_eligible_methods_preferences_payment_source_constraint: {
+            /** @enum {string} */
+            constraint_type: "INCLUDE";
+            payment_sources: string[];
+        };
+        paypal_v2_order: {
             create_time: string;
             update_time: string;
-            links: components["schemas"]["paypal_v1_common_link"][];
-            redirect_urls: components["schemas"]["paypal_v1_payment_redirect_urls"];
-            application_context: components["schemas"]["paypal_v1_payment_application_context"];
-            payment_instruction: components["schemas"]["paypal_v1_payment_payment_instruction"] | null;
-        };
-        paypal_v2_referral: {
-            business_entity: components["schemas"]["paypal_v2_referral_business_entity"];
-            preferred_language_code: string;
-            tracking_id: string;
-            partner_config_override: components["schemas"]["paypal_v2_referral_partner_config_override"];
-            operations: components["schemas"]["paypal_v2_referral_operation"][];
-            products: string[];
-            capabilities: string[];
-            legal_consents: components["schemas"]["paypal_v2_referral_legal_consent"][];
+            id: string;
+            /** @enum {string} */
+            intent: "CAPTURE" | "AUTHORIZE";
+            payer: components["schemas"]["paypal_v2_order_payer"];
+            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][] | null;
+            application_context: components["schemas"]["paypal_v2_order_application_context"];
+            payment_source: components["schemas"]["paypal_v2_order_payment_source"] | null;
+            status: string;
+            processing_instruction: string;
             links: components["schemas"]["paypal_v2_common_link"][];
-            legal_country_code: string;
         };
         paypal_v2_order_application_context: {
             brand_name: string;
@@ -1392,32 +1512,34 @@ export interface components {
             return_url: string;
             cancel_url: string;
         };
-        paypal_v2_order_tracker: {
-            capture_id: string;
-            tracking_number: string;
-            carrier: string;
-            carrier_name_other: string | null;
-            /** @default false */
-            notify_payer: boolean;
-            items: components["schemas"]["paypal_v2_order_purchase_unit_shipping_tracker_item"][];
+        paypal_v2_order_payer: {
+            name: components["schemas"]["paypal_v2_common_name"];
+            email_address: string;
+            payer_id: string;
+            phone: components["schemas"]["paypal_v2_order_payment_source_common_phone"] | null;
+            address: components["schemas"]["paypal_v2_common_address"];
         };
-        paypal_v2_order_purchase_unit: {
-            reference_id: string;
-            amount: components["schemas"]["paypal_v2_order_purchase_unit_amount"];
-            payee: components["schemas"]["paypal_v2_order_purchase_unit_payee"];
-            description: string;
-            custom_id: string | null;
-            invoice_id: string | null;
-            items: components["schemas"]["paypal_v2_order_purchase_unit_item"][] | null;
-            shipping: components["schemas"]["paypal_v2_order_purchase_unit_shipping"];
-            payments: components["schemas"]["paypal_v2_order_purchase_unit_payments"] | null;
-            supplementary_data: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data"];
-            shipping_options: components["schemas"]["paypal_v2_order_purchase_unit_shipping_option"][] | null;
-        };
-        paypal_v2_order_payment_source_google_pay: {
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+        paypal_v2_order_payment_source: {
+            afterpay: components["schemas"]["paypal_v2_order_payment_source_afterpay"] | null;
+            apple_pay: components["schemas"]["paypal_v2_order_payment_source_apple_pay"];
+            pay_upon_invoice: components["schemas"]["paypal_v2_order_payment_source_pay_upon_invoice"] | null;
+            bancontact: components["schemas"]["paypal_v2_order_payment_source_bancontact"] | null;
+            blik: components["schemas"]["paypal_v2_order_payment_source_blik"] | null;
+            boletobancario: components["schemas"]["paypal_v2_order_payment_source_boletobancario"] | null;
             card: components["schemas"]["paypal_v2_order_payment_source_card"] | null;
-            attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
+            eps: components["schemas"]["paypal_v2_order_payment_source_eps"] | null;
+            ideal: components["schemas"]["paypal_v2_order_payment_source_ideal"] | null;
+            klarna: components["schemas"]["paypal_v2_order_payment_source_klarna"] | null;
+            multibanco: components["schemas"]["paypal_v2_order_payment_source_multibanco"] | null;
+            my_bank: components["schemas"]["paypal_v2_order_payment_source_my_bank"] | null;
+            oxxo: components["schemas"]["paypal_v2_order_payment_source_oxxo"] | null;
+            p_2_4: components["schemas"]["paypal_v2_order_payment_source_p24"] | null;
+            paypal: components["schemas"]["paypal_v2_order_payment_source_paypal"] | null;
+            swish: components["schemas"]["paypal_v2_order_payment_source_swish"] | null;
+            token: components["schemas"]["paypal_v2_order_payment_source_token"] | null;
+            trustly: components["schemas"]["paypal_v2_order_payment_source_trustly"] | null;
+            google_pay: components["schemas"]["paypal_v2_order_payment_source_google_pay"] | null;
+            venmo: components["schemas"]["paypal_v2_order_payment_source_venmo"] | null;
         };
         paypal_v2_order_payment_source_afterpay: {
             name: string;
@@ -1428,18 +1550,17 @@ export interface components {
             /** Format: date */
             birth_date: string;
         };
-        paypal_v2_order_payment_source_oxxo: {
+        paypal_v2_order_payment_source_apple_pay: {
             name: string;
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            email: string;
+            card: components["schemas"]["paypal_v2_order_payment_source_card"] | null;
+            attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
         };
-        paypal_v2_order_payment_source_klarna: {
+        paypal_v2_order_payment_source_bancontact: {
             name: string;
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            email: string;
-            phone: string;
         };
         paypal_v2_order_payment_source_blik: {
             name: string;
@@ -1447,41 +1568,39 @@ export interface components {
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
             email: string;
         };
-        paypal_v2_order_payment_source_token_stored_payment_source: {
-            payment_initiator: string;
-            payment_type: string;
-            usage: string;
-        };
-        paypal_v2_order_payment_source_pay_upon_invoice: {
+        paypal_v2_order_payment_source_boletobancario: {
+            name: string;
+            country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            name: components["schemas"]["paypal_v2_common_name"];
             email: string;
-            birth_date: string;
-            phone: components["schemas"]["paypal_v2_common_phone_number"];
+            expiry_date: string;
+            tax_info: components["schemas"]["paypal_v2_order_payment_source_boletobancario_tax_info"];
             billing_address: components["schemas"]["paypal_v2_common_address"];
-            payment_reference: string;
-            deposit_bank_details: components["schemas"]["paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details"];
         };
         paypal_v2_order_payment_source_boletobancario_tax_info: {
             tax_id: string;
             tax_id_type: string;
         };
-        paypal_v2_order_payment_source_eps: {
+        paypal_v2_order_payment_source_card: {
             name: string;
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-        };
-        paypal_v2_order_payment_source_token: {
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            id: string;
+            last_digits: string;
+            brand: string;
             type: string;
-            stored_payment_source: components["schemas"]["paypal_v2_order_payment_source_token_stored_payment_source"];
+            vault_id: string;
+            billing_address: components["schemas"]["paypal_v2_common_address"] | null;
+            authentication_result: components["schemas"]["paypal_v2_order_payment_source_card_authentication_result"] | null;
+            attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
+            stored_credential: components["schemas"]["paypal_v2_order_payment_source_card_stored_credential"] | null;
         };
-        paypal_v2_order_payment_source_p24: {
-            name: string;
-            country_code: string;
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            email: string;
+        paypal_v2_order_payment_source_card_authentication_result: {
+            liability_shift: string | null;
+            three_d_secure: components["schemas"]["paypal_v2_order_payment_source_card_authentication_result_3d_secure"] | null;
+        };
+        paypal_v2_order_payment_source_card_authentication_result_3d_secure: {
+            enrollment_status: string;
+            authentication_status: string;
         };
         paypal_v2_order_payment_source_card_stored_credential: {
             /** @enum {string} */
@@ -1492,37 +1611,9 @@ export interface components {
             usage: "DERIVED" | "FIRST" | "SUBSEQUENT";
             previous_network_transaction_reference: string;
         };
-        paypal_v2_order_payment_source_card_authentication_result: {
-            liability_shift: string;
-            three_d_secure: components["schemas"]["paypal_v2_order_payment_source_card_authentication_result_3d_secure"] | null;
-        };
-        paypal_v2_order_payment_source_card_authentication_result_3d_secure: {
-            enrollment_status: string;
-            authentication_status: string;
-        };
-        paypal_v2_order_payment_source_common_phone: {
-            phone_type: string;
-            phone_number: components["schemas"]["paypal_v2_common_phone_number"];
-        };
-        paypal_v2_order_payment_source_common_attributes_customer: {
-            id: string;
-        };
-        paypal_v2_order_payment_source_common_attributes_vault: {
-            id: string | null;
-            store_in_vault: string;
-            usage_type: string;
-            status: string;
-            confirm_payment_token: string;
-            permit_multiple_payment_tokens: boolean;
-            customer: components["schemas"]["paypal_v2_order_payment_source_common_attributes_customer"] | null;
-            links: components["schemas"]["paypal_v2_common_link"][];
-        };
-        paypal_v2_order_payment_source_common_attributes_order_update_callback_config: {
-            callback_url: string;
-            callback_events: ("SHIPPING_ADDRESS" | "SHIPPING_OPTIONS")[];
-        };
-        paypal_v2_order_payment_source_common_attributes_verification: {
-            method: string;
+        paypal_v2_order_payment_source_common_app_switch_context: {
+            native_app: components["schemas"]["paypal_v2_order_payment_source_common_app_switch_context_native_app_context"] | null;
+            mobile_web: components["schemas"]["paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context"] | null;
         };
         paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context: {
             /**
@@ -1537,9 +1628,30 @@ export interface components {
             os_type: "ANDROID" | "IOS" | "OTHER";
             os_version: string;
         };
-        paypal_v2_order_payment_source_common_app_switch_context: {
-            native_app: components["schemas"]["paypal_v2_order_payment_source_common_app_switch_context_native_app_context"] | null;
-            mobile_web: components["schemas"]["paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context"] | null;
+        paypal_v2_order_payment_source_common_attributes: {
+            vault: components["schemas"]["paypal_v2_order_payment_source_common_attributes_vault"];
+            customer: components["schemas"]["paypal_v2_order_payment_source_common_attributes_customer"];
+            verification: components["schemas"]["paypal_v2_order_payment_source_common_attributes_verification"];
+        };
+        paypal_v2_order_payment_source_common_attributes_customer: {
+            id: string;
+        };
+        paypal_v2_order_payment_source_common_attributes_order_update_callback_config: {
+            callback_url: string;
+            callback_events: ("SHIPPING_ADDRESS" | "SHIPPING_OPTIONS")[];
+        };
+        paypal_v2_order_payment_source_common_attributes_vault: {
+            id: string | null;
+            store_in_vault: string;
+            usage_type: string;
+            status: string;
+            confirm_payment_token: string;
+            permit_multiple_payment_tokens: boolean;
+            customer: components["schemas"]["paypal_v2_order_payment_source_common_attributes_customer"] | null;
+            links: components["schemas"]["paypal_v2_common_link"][];
+        };
+        paypal_v2_order_payment_source_common_attributes_verification: {
+            method: string;
         };
         paypal_v2_order_payment_source_common_experience_context: {
             locale: string;
@@ -1572,12 +1684,33 @@ export interface components {
             order_update_callback_config: components["schemas"]["paypal_v2_order_payment_source_common_attributes_order_update_callback_config"];
             app_switch_context: components["schemas"]["paypal_v2_order_payment_source_common_app_switch_context"] | null;
         };
-        paypal_v2_order_payment_source_common_attributes: {
-            vault: components["schemas"]["paypal_v2_order_payment_source_common_attributes_vault"];
-            customer: components["schemas"]["paypal_v2_order_payment_source_common_attributes_customer"];
-            verification: components["schemas"]["paypal_v2_order_payment_source_common_attributes_verification"];
+        paypal_v2_order_payment_source_common_phone: {
+            phone_type: string;
+            phone_number: components["schemas"]["paypal_v2_common_phone_number"];
         };
-        paypal_v2_order_payment_source_bancontact: {
+        paypal_v2_order_payment_source_eps: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+        };
+        paypal_v2_order_payment_source_google_pay: {
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            card: components["schemas"]["paypal_v2_order_payment_source_card"] | null;
+            attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
+        };
+        paypal_v2_order_payment_source_ideal: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+        };
+        paypal_v2_order_payment_source_klarna: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            email: string;
+            phone: string;
+        };
+        paypal_v2_order_payment_source_multibanco: {
             name: string;
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
@@ -1587,10 +1720,33 @@ export interface components {
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
         };
-        paypal_v2_order_payment_source_trustly: {
+        paypal_v2_order_payment_source_oxxo: {
             name: string;
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            email: string;
+        };
+        paypal_v2_order_payment_source_p24: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            email: string;
+        };
+        paypal_v2_order_payment_source_pay_upon_invoice: {
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            name: components["schemas"]["paypal_v2_common_name"];
+            email: string;
+            birth_date: string;
+            phone: components["schemas"]["paypal_v2_common_phone_number"];
+            billing_address: components["schemas"]["paypal_v2_common_address"];
+            payment_reference: string;
+            deposit_bank_details: components["schemas"]["paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details"];
+        };
+        paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details: {
+            bic: string;
+            bank_name: string;
+            iban: string;
+            account_holder_name: string;
         };
         paypal_v2_order_payment_source_paypal: {
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
@@ -1605,44 +1761,27 @@ export interface components {
             phone_type: string;
             attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
         };
-        paypal_v2_order_payment_source_pay_upon_invoice_deposit_bank_details: {
-            bic: string;
-            bank_name: string;
-            iban: string;
-            account_holder_name: string;
-        };
-        paypal_v2_order_payment_source_boletobancario: {
-            name: string;
-            country_code: string;
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            email: string;
-            expiry_date: string;
-            tax_info: components["schemas"]["paypal_v2_order_payment_source_boletobancario_tax_info"];
-            billing_address: components["schemas"]["paypal_v2_common_address"];
-        };
-        paypal_v2_order_payment_source_card: {
-            name: string;
-            country_code: string;
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            last_digits: string;
-            brand: string;
-            type: string;
-            vault_id: string;
-            billing_address: components["schemas"]["paypal_v2_common_address"] | null;
-            authentication_result: components["schemas"]["paypal_v2_order_payment_source_card_authentication_result"] | null;
-            attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
-            stored_credential: components["schemas"]["paypal_v2_order_payment_source_card_stored_credential"] | null;
-        };
-        paypal_v2_order_payment_source_ideal: {
-            name: string;
-            country_code: string;
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-        };
         paypal_v2_order_payment_source_swish: {
             name: string;
             country_code: string;
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
             phone: string;
+        };
+        paypal_v2_order_payment_source_token: {
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
+            id: string;
+            type: string;
+            stored_payment_source: components["schemas"]["paypal_v2_order_payment_source_token_stored_payment_source"];
+        };
+        paypal_v2_order_payment_source_token_stored_payment_source: {
+            payment_initiator: string;
+            payment_type: string;
+            usage: string;
+        };
+        paypal_v2_order_payment_source_trustly: {
+            name: string;
+            country_code: string;
+            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
         };
         paypal_v2_order_payment_source_venmo: {
             experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
@@ -1655,51 +1794,21 @@ export interface components {
             address: components["schemas"]["paypal_v2_common_address"];
             attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
         };
-        paypal_v2_order_payment_source_apple_pay: {
-            name: string;
-            country_code: string;
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-            card: components["schemas"]["paypal_v2_order_payment_source_card"] | null;
-            attributes: components["schemas"]["paypal_v2_order_payment_source_common_attributes"] | null;
+        paypal_v2_order_purchase_unit: {
+            reference_id: string;
+            amount: components["schemas"]["paypal_v2_order_purchase_unit_amount"];
+            payee: components["schemas"]["paypal_v2_order_purchase_unit_payee"];
+            description: string;
+            custom_id: string | null;
+            invoice_id: string | null;
+            items: components["schemas"]["paypal_v2_order_purchase_unit_item"][] | null;
+            shipping: components["schemas"]["paypal_v2_order_purchase_unit_shipping"];
+            payments: components["schemas"]["paypal_v2_order_purchase_unit_payments"] | null;
+            supplementary_data: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data"];
+            shipping_options: components["schemas"]["paypal_v2_order_purchase_unit_shipping_option"][] | null;
         };
-        paypal_v2_order_payment_source_multibanco: {
-            name: string;
-            country_code: string;
-            experience_context: components["schemas"]["paypal_v2_order_payment_source_common_experience_context"];
-        };
-        paypal_v2_order_payer: {
-            name: components["schemas"]["paypal_v2_common_name"];
-            email_address: string;
-            payer_id: string;
-            phone: components["schemas"]["paypal_v2_order_payment_source_common_phone"] | null;
-            address: components["schemas"]["paypal_v2_common_address"];
-        };
-        paypal_v2_order_payment_source: {
-            afterpay: components["schemas"]["paypal_v2_order_payment_source_afterpay"] | null;
-            apple_pay: components["schemas"]["paypal_v2_order_payment_source_apple_pay"];
-            pay_upon_invoice: components["schemas"]["paypal_v2_order_payment_source_pay_upon_invoice"] | null;
-            bancontact: components["schemas"]["paypal_v2_order_payment_source_bancontact"] | null;
-            blik: components["schemas"]["paypal_v2_order_payment_source_blik"] | null;
-            boletobancario: components["schemas"]["paypal_v2_order_payment_source_boletobancario"] | null;
-            card: components["schemas"]["paypal_v2_order_payment_source_card"] | null;
-            eps: components["schemas"]["paypal_v2_order_payment_source_eps"] | null;
-            ideal: components["schemas"]["paypal_v2_order_payment_source_ideal"] | null;
-            klarna: components["schemas"]["paypal_v2_order_payment_source_klarna"] | null;
-            multibanco: components["schemas"]["paypal_v2_order_payment_source_multibanco"] | null;
-            my_bank: components["schemas"]["paypal_v2_order_payment_source_my_bank"] | null;
-            oxxo: components["schemas"]["paypal_v2_order_payment_source_oxxo"] | null;
-            p_2_4: components["schemas"]["paypal_v2_order_payment_source_p24"] | null;
-            paypal: components["schemas"]["paypal_v2_order_payment_source_paypal"] | null;
-            swish: components["schemas"]["paypal_v2_order_payment_source_swish"] | null;
-            token: components["schemas"]["paypal_v2_order_payment_source_token"] | null;
-            trustly: components["schemas"]["paypal_v2_order_payment_source_trustly"] | null;
-            google_pay: components["schemas"]["paypal_v2_order_payment_source_google_pay"] | null;
-            venmo: components["schemas"]["paypal_v2_order_payment_source_venmo"] | null;
-        };
-        paypal_v2_order_purchase_unit_payee: {
-            email_address: string;
-            merchant_id: string;
-            display_data: components["schemas"]["paypal_v2_order_purchase_unit_payee_display_data"];
+        paypal_v2_order_purchase_unit_amount: components["schemas"]["paypal_v2_common_money"] & {
+            breakdown: components["schemas"]["paypal_v2_order_purchase_unit_amount_breakdown"] | null;
         };
         paypal_v2_order_purchase_unit_amount_breakdown: {
             item_total: components["schemas"]["paypal_v2_common_money"];
@@ -1709,6 +1818,44 @@ export interface components {
             insurance: components["schemas"]["paypal_v2_common_money"];
             shipping_discount: components["schemas"]["paypal_v2_common_money"];
             discount: components["schemas"]["paypal_v2_common_money"];
+        };
+        paypal_v2_order_purchase_unit_item: {
+            name: string;
+            unit_amount: components["schemas"]["paypal_v2_common_money"];
+            tax: components["schemas"]["paypal_v2_common_money"];
+            tax_rate: string | number | Record<string, unknown>;
+            /** @enum {string} */
+            category: "PHYSICAL_GOODS" | "DIGITAL_GOODS" | "DONATION";
+            quantity: number;
+            sku: string | null;
+        };
+        paypal_v2_order_purchase_unit_payee: {
+            email_address: string;
+            merchant_id: string;
+            display_data: components["schemas"]["paypal_v2_order_purchase_unit_payee_display_data"];
+        };
+        paypal_v2_order_purchase_unit_payee_display_data: {
+            brand_name: string;
+        };
+        paypal_v2_order_purchase_unit_payments: {
+            authorizations: components["schemas"]["paypal_v2_order_purchase_unit_payments_authorization"][] | null;
+            captures: components["schemas"]["paypal_v2_order_purchase_unit_payments_capture"][] | null;
+            refunds: components["schemas"]["paypal_v2_order_purchase_unit_payments_refund"][] | null;
+        };
+        paypal_v2_order_purchase_unit_payments_authorization: {
+            status: string;
+            id: string;
+            amount: components["schemas"]["paypal_v2_common_money"] | null;
+            custom_id: string | null;
+            links: components["schemas"]["paypal_v2_common_link"][];
+            create_time: string;
+            update_time: string;
+            seller_protection: components["schemas"]["paypal_v2_order_purchase_unit_payments_common_seller_protection"];
+            expiration_time: string;
+        };
+        paypal_v2_order_purchase_unit_payments_authorization_seller_protection: {
+            status: string;
+            dispute_categories: string[];
         };
         paypal_v2_order_purchase_unit_payments_capture: {
             status: string;
@@ -1726,6 +1873,20 @@ export interface components {
             processor_response: components["schemas"]["paypal_v2_order_purchase_unit_payments_capture_processor_response"];
             disbursement_mode: string;
         };
+        paypal_v2_order_purchase_unit_payments_capture_processor_response: {
+            avs_code: string | null;
+            cvv_code: string | null;
+            response_code: string | null;
+        };
+        paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown: {
+            gross_amount: components["schemas"]["paypal_v2_common_money"];
+            paypal_fee: components["schemas"]["paypal_v2_common_money"];
+            net_amount: components["schemas"]["paypal_v2_common_money"];
+        };
+        paypal_v2_order_purchase_unit_payments_common_seller_protection: {
+            status: string;
+            dispute_categories: string[];
+        };
         paypal_v2_order_purchase_unit_payments_refund: {
             status: string;
             id: string;
@@ -1738,69 +1899,19 @@ export interface components {
             note_to_payer: string | null;
             seller_payable_breakdown: components["schemas"]["paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown"];
         };
-        paypal_v2_order_purchase_unit_payments_authorization: {
-            status: string;
-            id: string;
-            amount: components["schemas"]["paypal_v2_common_money"] | null;
-            custom_id: string | null;
-            links: components["schemas"]["paypal_v2_common_link"][];
-            create_time: string;
-            update_time: string;
-            seller_protection: components["schemas"]["paypal_v2_order_purchase_unit_payments_common_seller_protection"];
-            expiration_time: string;
-        };
-        paypal_v2_order_purchase_unit_payments_common_seller_protection: {
-            status: string;
-            dispute_categories: string[];
-        };
         paypal_v2_order_purchase_unit_payments_refund_seller_payable_breakdown: {
             gross_amount: components["schemas"]["paypal_v2_common_money"];
             paypal_fee: components["schemas"]["paypal_v2_common_money"];
             net_amount: components["schemas"]["paypal_v2_common_money"];
             total_refunded_amount: components["schemas"]["paypal_v2_common_money"];
         };
-        paypal_v2_order_purchase_unit_payments_authorization_seller_protection: {
-            status: string;
-            dispute_categories: string[];
-        };
-        paypal_v2_order_purchase_unit_payments_capture_processor_response: {
-            avs_code: string | null;
-            cvv_code: string | null;
-            response_code: string | null;
-        };
-        paypal_v2_order_purchase_unit_payments_capture_seller_receivable_breakdown: {
-            gross_amount: components["schemas"]["paypal_v2_common_money"];
-            paypal_fee: components["schemas"]["paypal_v2_common_money"];
-            net_amount: components["schemas"]["paypal_v2_common_money"];
-        };
-        paypal_v2_order_purchase_unit_item: {
-            name: string;
-            unit_amount: components["schemas"]["paypal_v2_common_money"];
-            tax: components["schemas"]["paypal_v2_common_money"];
-            tax_rate: string | number | Record<string, unknown>;
-            /** @enum {string} */
-            category: "PHYSICAL_GOODS" | "DIGITAL_GOODS" | "DONATION";
-            quantity: number;
-            sku: string | null;
-        };
-        paypal_v2_order_purchase_unit_payments: {
-            authorizations: components["schemas"]["paypal_v2_order_purchase_unit_payments_authorization"][] | null;
-            captures: components["schemas"]["paypal_v2_order_purchase_unit_payments_capture"][] | null;
-            refunds: components["schemas"]["paypal_v2_order_purchase_unit_payments_refund"][] | null;
-        };
-        paypal_v2_order_purchase_unit_supplementary_data: {
-            card: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_card"];
-            risk: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_risk"];
+        paypal_v2_order_purchase_unit_shipping: {
+            name: components["schemas"]["paypal_v2_order_purchase_unit_shipping_name"];
+            address: components["schemas"]["paypal_v2_common_address"];
+            trackers: components["schemas"]["paypal_v2_order_purchase_unit_shipping_tracker"][] | null;
         };
         paypal_v2_order_purchase_unit_shipping_name: {
             full_name: string;
-        };
-        paypal_v2_order_purchase_unit_shipping_tracker_item: {
-            name: string;
-            quantity: number;
-            sku: string | null;
-            url: string | null;
-            image_url: string | null;
         };
         paypal_v2_order_purchase_unit_shipping_tracker: {
             id: string;
@@ -1808,6 +1919,13 @@ export interface components {
             notify_payer: boolean;
             links: components["schemas"]["paypal_v2_common_link"][];
             items: components["schemas"]["paypal_v2_order_purchase_unit_item"][];
+        };
+        paypal_v2_order_purchase_unit_shipping_tracker_item: {
+            name: string;
+            quantity: number;
+            sku: string | null;
+            url: string | null;
+            image_url: string | null;
         };
         paypal_v2_order_purchase_unit_shipping_option: {
             id: string;
@@ -1817,19 +1935,24 @@ export interface components {
             type: "SHIPPING" | "PICKUP";
             selected: boolean;
         };
-        paypal_v2_order_purchase_unit_payee_display_data: {
-            brand_name: string;
+        paypal_v2_order_purchase_unit_supplementary_data: {
+            card: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_card"];
+            risk: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_risk"];
         };
-        paypal_v2_order_purchase_unit_amount: components["schemas"]["paypal_v2_common_money"] & {
-            breakdown: components["schemas"]["paypal_v2_order_purchase_unit_amount_breakdown"] | null;
+        paypal_v2_order_purchase_unit_supplementary_data_card: {
+            address: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_card_level2"];
         };
-        paypal_v2_order_purchase_unit_shipping: {
-            name: components["schemas"]["paypal_v2_order_purchase_unit_shipping_name"];
-            address: components["schemas"]["paypal_v2_common_address"];
-            trackers: components["schemas"]["paypal_v2_order_purchase_unit_shipping_tracker"][] | null;
+        paypal_v2_order_purchase_unit_supplementary_data_card_level2: {
+            invoice_id: string;
+            tax_total: components["schemas"]["paypal_v2_common_money"];
         };
-        paypal_v2_order_purchase_unit_supplementary_data_risk: {
-            address: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_risk_participant_metadata"];
+        paypal_v2_order_purchase_unit_supplementary_data_card_level3: {
+            shipping_amount: components["schemas"]["paypal_v2_common_money"];
+            duty_amount: components["schemas"]["paypal_v2_common_money"];
+            discount_amount: components["schemas"]["paypal_v2_common_money"];
+            shipping_address: components["schemas"]["paypal_v2_common_address"];
+            ships_from_postal_code: string;
+            line_items: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_card_line_item"][];
         };
         paypal_v2_order_purchase_unit_supplementary_data_card_line_item: {
             name: string;
@@ -1846,139 +1969,26 @@ export interface components {
             total_amount: components["schemas"]["paypal_v2_common_money"];
             unit_of_measure: string;
         };
-        paypal_v2_order_purchase_unit_supplementary_data_card_level2: {
-            invoice_id: string;
-            tax_total: components["schemas"]["paypal_v2_common_money"];
-        };
-        paypal_v2_order_purchase_unit_supplementary_data_card_level3: {
-            shipping_amount: components["schemas"]["paypal_v2_common_money"];
-            duty_amount: components["schemas"]["paypal_v2_common_money"];
-            discount_amount: components["schemas"]["paypal_v2_common_money"];
-            shipping_address: components["schemas"]["paypal_v2_common_address"];
-            ships_from_postal_code: string;
-            line_items: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_card_line_item"][];
+        paypal_v2_order_purchase_unit_supplementary_data_risk: {
+            address: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_risk_participant_metadata"];
         };
         paypal_v2_order_purchase_unit_supplementary_data_risk_participant_metadata: {
             ip_address: string;
         };
-        paypal_v2_order_purchase_unit_supplementary_data_card: {
-            address: components["schemas"]["paypal_v2_order_purchase_unit_supplementary_data_card_level2"];
+        paypal_v2_order_tracker: {
+            capture_id: string;
+            tracking_number: string;
+            carrier: string;
+            carrier_name_other: string | null;
+            /** @default false */
+            notify_payer: boolean;
+            items: components["schemas"]["paypal_v2_order_purchase_unit_shipping_tracker_item"][];
         };
-        paypal_v2_eligible_methods_data: {
-            eligible_methods: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods"];
-            supplementary_data: components["schemas"]["paypal_v2_eligible_methods_data_supplementary_data"];
-        };
-        paypal_v2_find_eligible_methods: {
-            customer: components["schemas"]["paypal_v2_find_eligible_methods_customer"];
-            preferences: components["schemas"]["paypal_v2_find_eligible_methods_preferences"];
-            /**
-             * @description Does not have to be a full purchase unit.
-             *     `[{"amount":{"currency_code":"<iso-4217-code>"},"payee":{"merchant_id":"<merchant-id>"}}]` is enough.
-             */
-            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][];
-        };
-        paypal_v2_eligible_methods_data_eligible_methods_google_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
-            config: Record<string, unknown>[];
-        };
-        paypal_v2_eligible_methods_data_eligible_methods_klarna: Record<string, unknown>;
-        paypal_v2_eligible_methods_data_eligible_methods_blik: Record<string, unknown>;
-        paypal_v2_eligible_methods_data_eligible_methods_advanced_cards: {
-            supports_installements: boolean;
-            cobranded_enabled: boolean;
-            vendors: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor"][];
-        };
-        paypal_v2_eligible_methods_data_eligible_methods_bizum: Record<string, unknown>;
-        paypal_v2_eligible_methods_data_eligible_methods_eps: Record<string, unknown>;
-        paypal_v2_eligible_methods_data_eligible_methods_p24: Record<string, unknown>;
-        paypal_v2_eligible_methods_data_eligible_methods_advanced_cards_vendor: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
-            eligible: boolean;
-            network: string;
-            branded: boolean;
-        };
-        paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
-            /** @description ISO 3166-1 alpha-2 country code */
-            country_code: string;
-            product_code: string;
-        };
-        paypal_v2_eligible_methods_data_eligible_methods_bancontact: Record<string, unknown>;
-        paypal_v2_eligible_methods_data_eligible_methods_paypal: {
-            can_be_vaulted: boolean;
-        };
-        paypal_v2_eligible_methods_data_eligible_methods_ideal: Record<string, unknown>;
-        paypal_v2_eligible_methods_data_eligible_methods_apple_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"] & {
-            config: Record<string, unknown>[];
-        };
-        paypal_v2_eligible_methods_data_supplementary_data: {
-            /** @description ISO 3166-1 alpha-2 country code */
-            buyer_country_code: string;
-        };
-        paypal_v2_eligible_methods_data_eligible_methods: {
-            paypal: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal"];
-            paypal_pay_later: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_paypal_pay_later"];
-            apple_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_apple_pay"];
-            google_pay: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_google_pay"];
-            advanced_cards: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_advanced_cards"];
-            eps: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_eps"];
-            p_2_4: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_p24"];
-            blik: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_blik"];
-            ideal: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_ideal"];
-            bizum: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_bizum"];
-            bancontact: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_bancontact"];
-            klarna: components["schemas"]["paypal_v2_eligible_methods_data_eligible_methods_klarna"];
-        };
-        paypal_v2_order: {
-            create_time: string;
-            update_time: string;
+        paypal_v2_order_shipping_callback: {
             id: string;
-            /** @enum {string} */
-            intent: "CAPTURE" | "AUTHORIZE";
-            payer: components["schemas"]["paypal_v2_order_payer"];
-            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][] | null;
-            application_context: components["schemas"]["paypal_v2_order_application_context"];
-            payment_source: components["schemas"]["paypal_v2_order_payment_source"] | null;
-            status: string;
-            processing_instruction: string;
-            links: components["schemas"]["paypal_v2_common_link"][];
-        };
-        paypal_v2_common_name: {
-            given_name: string;
-            surname: string;
-        };
-        paypal_v2_common_phone_number: {
-            national_number: string;
-            country_code: string;
-        };
-        paypal_v2_common_link: {
-            href: string;
-            rel: string;
-            method: string;
-            enc_type: string | null;
-        };
-        paypal_v2_common_upc: {
-            type: string;
-            code: string;
-        };
-        paypal_v2_common_address: {
-            /**
-             * @description The first line of the address. For example, number or street. For example, 173 Drury Lane.
-             *     Required for data entry and compliance and risk checks. Must contain the full address.
-             */
-            address_line_1: string | null;
-            /** @description The second line of the address. For example, suite or apartment number. */
-            address_line_2: string | null;
-            /** @description A city, town, or village. Smaller than $adminArea1 */
-            admin_area_2: string | null;
-            /**
-             * @description The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.
-             *     Format for postal delivery. For example, CA and not California.
-             */
-            admin_area_1: string | null;
-            postal_code: string | null;
-            country_code: string;
-        };
-        paypal_v2_common_money: {
-            currency_code: string;
-            value: string;
+            shipping_address: components["schemas"]["paypal_v2_common_address"];
+            shipping_option: components["schemas"]["paypal_v2_order_purchase_unit_shipping_option"];
+            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][];
         };
         paypal_v2_patch: {
             op: string;
@@ -1986,17 +1996,38 @@ export interface components {
             value: (number | Record<string, unknown> | string | boolean | Record<string, unknown>[]) | null;
             from: string;
         };
+        paypal_v2_referral: {
+            business_entity: components["schemas"]["paypal_v2_referral_business_entity"];
+            preferred_language_code: string;
+            tracking_id: string;
+            partner_config_override: components["schemas"]["paypal_v2_referral_partner_config_override"];
+            operations: components["schemas"]["paypal_v2_referral_operation"][];
+            products: string[];
+            capabilities: string[];
+            legal_consents: components["schemas"]["paypal_v2_referral_legal_consent"][];
+            links: components["schemas"]["paypal_v2_common_link"][];
+            legal_country_code: string;
+        };
+        paypal_v2_referral_business_entity: {
+            addresses: components["schemas"]["paypal_v2_referral_business_entity_address"][];
+        };
+        paypal_v2_referral_business_entity_address: {
+            country_code: string;
+            /** @default WORK */
+            type: string;
+        };
+        paypal_v2_referral_legal_consent: {
+            /** @default SHARE_DATA_CONSENT */
+            type: string;
+            granted: boolean;
+        };
         paypal_v2_referral_operation: {
             /** @default API_INTEGRATION */
             operation: string;
             api_integration_preference: components["schemas"]["paypal_v2_referral_operation_api_integration_preference"];
         };
-        paypal_v2_referral_partner_config_override: {
-            return_url: string;
-            partner_logo_url: string;
-        };
-        paypal_v2_referral_business_entity: {
-            addresses: components["schemas"]["paypal_v2_referral_business_entity_address"][];
+        paypal_v2_referral_operation_api_integration_preference: {
+            rest_api_integration: components["schemas"]["paypal_v2_referral_operation_api_integration_preference_rest_api_integration"];
         };
         paypal_v2_referral_operation_api_integration_preference_rest_api_integration: {
             /** @default PAYPAL */
@@ -2011,51 +2042,20 @@ export interface components {
             signup_mode: string;
             organization: string;
         };
-        paypal_v2_referral_operation_api_integration_preference: {
-            rest_api_integration: components["schemas"]["paypal_v2_referral_operation_api_integration_preference_rest_api_integration"];
+        paypal_v2_referral_partner_config_override: {
+            return_url: string;
+            partner_logo_url: string;
         };
-        paypal_v2_referral_business_entity_address: {
-            country_code: string;
-            /** @default WORK */
-            type: string;
-        };
-        paypal_v2_referral_legal_consent: {
-            /** @default SHARE_DATA_CONSENT */
-            type: string;
-            granted: boolean;
-        };
-        paypal_v2_confirm_order: {
-            payment_source: components["schemas"]["paypal_v2_order_payment_source"];
-        };
-        paypal_v2_find_eligible_methods_customer_channel: {
-            browser_type: string | null;
-            client_os: string | null;
-            device_type: string | null;
-        };
-        paypal_v2_find_eligible_methods_customer: {
-            /** @description ISO 3166-1 alpha-2 country code */
-            country_code: string;
-            channel: components["schemas"]["paypal_v2_find_eligible_methods_customer_channel"];
-        };
-        paypal_v2_find_eligible_methods_preferences_payment_source_constraint: {
-            /** @enum {string} */
-            constraint_type: "INCLUDE";
-            payment_sources: string[];
-        };
-        paypal_v2_find_eligible_methods_preferences: {
-            /** @enum {string} */
-            payment_flow: "ONE_TIME_PAYMENT";
-            commit: boolean;
-            /** @enum {string} */
-            intent: "CAPTURE" | "AUTHORIZE";
-            vault: boolean;
-            payment_source_constraint: components["schemas"]["paypal_v2_find_eligible_methods_preferences_payment_source_constraint"];
-        };
-        paypal_v2_order_shipping_callback: {
+        paypal_v3_payment_token: {
             id: string;
-            shipping_address: components["schemas"]["paypal_v2_common_address"];
-            shipping_option: components["schemas"]["paypal_v2_order_purchase_unit_shipping_option"];
-            purchase_units: components["schemas"]["paypal_v2_order_purchase_unit"][];
+            status: string;
+            customer: components["schemas"]["paypal_v2_order_payment_source_common_attributes_customer"];
+            payment_source: components["schemas"]["paypal_v2_order_payment_source"];
+            links: components["schemas"]["paypal_v2_common_link"][];
+            metadata: components["schemas"]["paypal_v3_payment_token_metadata"] | null;
+        };
+        paypal_v3_payment_token_metadata: {
+            order_id: string;
         };
         error: {
             code: string;


### PR DESCRIPTION
### 1. Why is this change necessary?

`validate-openapi-typescript` has been red on trunk since #778 and blocks every pull request, for two independent reasons: the generator scans the PayPal SDK structs in filesystem order, which differs per machine, and the committed schema was generated against a newer SDK than the one CI validates with.

### 2. What does this change do, exactly?

Sorts that `Finder` by name so the order of `components.schemas` is identical everywhere, and commits the schema regenerated against paypal-sdk v1.8.0 — the version CI installs via `--prefer-lowest`.

### 3. Describe each step to reproduce the issue or behaviour.

Run `composer openapi:generate` on any machine other than the one that last committed the schema, then `git diff src/Resources/Schema`.

### 4. Please link to the relevant issues (if any).

- relates #778
- unblocks #780

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

<!--
Notes for review:

* Two independent defects, hence two commits. Ordering: an unsorted `Finder` let filesystem order decide
  the schema order — stable within one machine, different on every CI runner, so regenerating always looked
  correct locally and always failed in CI. Content: CI runs `--prefer-lowest` (paypal-sdk v1.8.0), where
  `liability_shift` is a non-nullable string; regenerating with a newer local SDK reintroduces the drift.
  #778 hit both, which is why regenerating in good faith did not help.
* Apart from `liability_shift`, the regenerated files carry no content change — the same 219 schemas, reordered.
* No CHANGELOG entry: internal devops tooling with no user-facing effect, matching #760 (`fix(devops):`).
* No unit test: a generate-twice test passes even without the sort fix, since scan order is stable within one
  machine and only varies between machines. The working guard is `validate-openapi-typescript` itself — now
  that the schema is stable, dropping the sort makes that job fail on the next runner.
-->
