### PR TITLE
fix: type-hint credentials and token service interfaces

### DIFF
--- a/src/AgenticCommerce/HoneyWebhookService.php
+++ b/src/AgenticCommerce/HoneyWebhookService.php
@@ -26,7 +26,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Swag\PayPal\AgenticCommerce\Exception\HoneyWebhookException;
 use Swag\PayPal\AgenticCommerce\Util\FaviconLoader;
-use Swag\PayPal\Setting\Service\CredentialsUtil;
+use Swag\PayPal\Setting\Service\CredentialsUtilInterface;
 use Swag\PayPal\Setting\Settings;
 use Swag\PayPal\SwagPayPal;
 use Symfony\Component\Routing\RouterInterface;
@@ -43,7 +43,7 @@ class HoneyWebhookService
     public function __construct(
         private readonly ClientInterface $client,
         private readonly EntityRepository $salesChannelRepository,
-        private readonly CredentialsUtil $credentialsUtil,
+        private readonly CredentialsUtilInterface $credentialsUtil,
         private readonly RouterInterface $router,
         private readonly SystemConfigService $systemConfigService,
         private readonly LoggerInterface $logger,

--- a/src/Setting/Service/MerchantIntegrationsService.php
+++ b/src/Setting/Service/MerchantIntegrationsService.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Struct\V1\MerchantIntegrations;
 use Swag\PayPal\RestApi\Exception\PayPalApiException;
 use Swag\PayPal\RestApi\V1\Resource\MerchantIntegrationsResourceInterface;
-use Swag\PayPal\RestApi\V1\Resource\TokenResource;
+use Swag\PayPal\RestApi\V1\Resource\TokenResourceInterface;
 use Swag\PayPal\Setting\Exception\PayPalSettingsInvalidException;
 use Swag\PayPal\Setting\Struct\MerchantInformationStruct;
 use Swag\PayPal\Util\Lifecycle\Method\AbstractMethodData;
@@ -28,7 +28,7 @@ class MerchantIntegrationsService
      */
     public function __construct(
         private readonly MerchantIntegrationsResourceInterface $merchantIntegrationsResource,
-        private readonly TokenResource $tokenResource,
+        private readonly TokenResourceInterface $tokenResource,
         private readonly CredentialsUtilInterface $credentialsUtil,
         private readonly PaymentMethodDataRegistry $paymentMethodDataRegistry,
     ) {


### PR DESCRIPTION
## Problem

`HoneyWebhookService` type-hinted the concrete `CredentialsUtil` class even though `CredentialsUtilInterface` already exists. Decorating the `Swag\PayPal\Setting\Service\CredentialsUtil` service id with an implementation that only implements the interface breaks the container:

```
TypeError: Swag\PayPal\AgenticCommerce\HoneyWebhookService::__construct():
Argument #3 ($credentialsUtil) must be of type Swag\PayPal\Setting\Service\CredentialsUtil,
Swag\SaasRufus\Core\PayPal\Setting\Service\SaasCredentialsUtil given
```

## Changes

| File | Was | Now |
|---|---|---|
| `src/AgenticCommerce/HoneyWebhookService.php` | `CredentialsUtil` | `CredentialsUtilInterface` |
| `src/Setting/Service/MerchantIntegrationsService.php` | `TokenResource` | `TokenResourceInterface` |

Both consumers only call methods declared on the interfaces (`getMerchantPayerId()`, `getToken()`), so no interface change was needed.

DI wiring is untouched — the XML keeps referencing the concrete service ids, matching how every other interface-typed consumer in the plugin is wired. That is the id a decorator replaces.

## Scan coverage

All 12 `*Interface.php` files in `src/` were checked for the same concrete-type-hint pattern. The only other hits were false positives: `Swag\PayPal\Pos\Resource\TokenResource` and `Swag\PayPal\Pos\Webhook\WebhookService` are distinct Pos classes with no interfaces of their own.

Existing tests mock/instantiate the concrete `CredentialsUtil`, which still satisfies the interface, so they were left unchanged.

## Verification

- PHPStan: 0 file errors on `src/AgenticCommerce`, `src/Setting` and their tests
- php-cs-fixer: clean on both files
- PHPUnit: `HoneyWebhookServiceTest` + `MerchantIntegrationsServiceTest` — 16 tests, 160 assertions, OK