### PR TITLE
fix: show Pay Later express button on listing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixes an issue, where a custom tax provider's adjusted total was not charged, because the PayPal order used the stale cart or order transaction amount instead of the taxed total (shopware/SwagPayPal#722)
 - Fixes an issue, where PayPal shipping tracking sync retried 429 RATE_LIMIT_REACHED responses too early instead of respecting the Retry-After header.
 - Fixes an issue, where the extension card context menu showed a raw snippet key instead of "Configure" (shopware/shopware#19028)
+- Fixes an issue, where the "Pay Later" express button was never shown on listing, search and CMS pages, because Pay Later was suppressed whenever no single product was available to evaluate (shopware/shopware#19027)
 
 # 10.8.0
 - Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -2,6 +2,7 @@
 - Behebt ein Problem, bei dem der von einem benutzerdefinierten Tax Provider angepasste Gesamtbetrag nicht berechnet wurde, weil die PayPal-Bestellung den veralteten Warenkorb- oder Bestelltransaktionsbetrag anstelle des besteuerten Gesamtbetrags verwendete (shopware/SwagPayPal#722)
 - Behebt ein Problem, bei dem die PayPal-Versandtracking-Synchronisierung 429 RATE_LIMIT_REACHED-Antworten zu früh erneut verarbeitet hat, anstatt den Retry-After-Header zu berücksichtigen.
 - Behebt ein Problem, bei dem im Kontextmenü der Erweiterungs-Kachel der rohe Snippet-Key statt „Konfigurieren” angezeigt wurde (shopware/shopware#19028)
+- Behebt ein Problem, bei dem der „Später Bezahlen”-Express-Button auf Listing-, Such- und CMS-Seiten nie angezeigt wurde, weil „Später Bezahlen” immer dann unterdrückt wurde, wenn kein einzelnes Produkt zur Prüfung verfügbar war (shopware/shopware#19027)
 
 # 10.8.0
 - Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)

--- a/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
+++ b/src/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataService.php
@@ -77,7 +77,8 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService
             $availabilityContext = AvailabilityContextBuilder::buildFromCart($cart, $salesChannelContext);
         }
 
-        if ($this->showPayLater($salesChannelId, $availabilityContext)) {
+        $showPayLater = $this->showPayLater($salesChannelId, $availabilityContext);
+        if ($showPayLater) {
             array_splice($fundingSources, 1, 0, ['paylater']);
         }
 
@@ -102,7 +103,7 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService
             ),
             'handleErrorUrl' => $this->router->generate('frontend.paypal.handle-error'),
             'cancelRedirectUrl' => $this->router->generate($addProductToCart ? 'frontend.checkout.cart.page' : 'frontend.checkout.register.page'),
-            'showPayLater' => $this->showPayLater($salesChannelId, $availabilityContext),
+            'showPayLater' => $showPayLater,
             'fundingSources' => $fundingSources,
         ]);
     }
@@ -114,8 +115,15 @@ class PayPalExpressCheckoutDataService extends AbstractScriptDataService
 
     private function showPayLater(string $salesChannelId, ?AvailabilityContext $availabilityContext): bool
     {
-        return $availabilityContext !== null
-            && $this->systemConfigService->getBool(Settings::ECS_SHOW_PAY_LATER, $salesChannelId)
-            && $this->payLaterMethodData->isAvailable($availabilityContext);
+        if (!$this->systemConfigService->getBool(Settings::ECS_SHOW_PAY_LATER, $salesChannelId)) {
+            return false;
+        }
+
+        // Listing, search and CMS pages have no product to evaluate; let PayPal's own eligibility check decide.
+        if ($availabilityContext === null) {
+            return true;
+        }
+
+        return $this->payLaterMethodData->isAvailable($availabilityContext);
     }
 }

--- a/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/PayPalExpressCheckoutDataServiceTest.php
@@ -37,6 +37,8 @@ use Shopware\Core\Test\TestDefaults;
 use Shopware\PayPalSDK\Struct\ConstantsV2;
 use Shopware\Storefront\Page\Product\ProductPage;
 use Shopware\Storefront\Page\Product\ProductPageLoadedEvent;
+use Shopware\Storefront\Pagelet\Wishlist\GuestWishlistPagelet;
+use Shopware\Storefront\Pagelet\Wishlist\GuestWishlistPageletLoadedEvent;
 use Swag\PayPal\Checkout\Cart\Service\CartPriceService;
 use Swag\PayPal\Checkout\ExpressCheckout\Service\PayPalExpressCheckoutDataService;
 use Swag\PayPal\Setting\Service\CredentialsUtil;
@@ -288,6 +290,50 @@ class PayPalExpressCheckoutDataServiceTest extends TestCase
             'PayLater not available' => [true, false, ['paypal', 'venmo']],
             'PayLater enabled and available' => [true, true, ['paypal', 'paylater', 'venmo']],
             'PayLater disabled and not available' => [false, false, ['paypal', 'venmo']],
+        ];
+    }
+
+    #[DataProvider('dataProviderTestFundingSourcesWithoutProductContext')]
+    public function testFundingSourcesWithoutProductContext(bool $showPayLaterSetting, array $expectedFundingSources): void
+    {
+        $salesChannelContext = $this->salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+
+        $this->systemConfigService->set(Settings::ECS_SHOW_PAY_LATER, $showPayLaterSetting, $salesChannelContext->getSalesChannelId());
+
+        $payLaterMethodData = $this->createMock(PayLaterMethodData::class);
+        $payLaterMethodData->expects($this->never())->method('isAvailable');
+
+        $payPalExpressCheckoutDataService = new PayPalExpressCheckoutDataService(
+            $this->getContainer()->get(CartService::class),
+            $this->getContainer()->get(LocaleCodeProvider::class),
+            $this->getContainer()->get('router'),
+            $this->paymentMethodUtil,
+            $this->systemConfigService,
+            new CredentialsUtil($this->systemConfigService),
+            $this->getContainer()->get(CartPriceService::class),
+            $payLaterMethodData
+        );
+
+        // Listing and CMS pages (ExpressCategoryRoute) pass no event at all.
+        $withoutEvent = $payPalExpressCheckoutDataService->buildExpressCheckoutButtonData($salesChannelContext, true);
+
+        // Pagelets pass an event that is not a ProductPageLoadedEvent, so no context is built either.
+        // GuestWishlist stands in for every PageletLoadedEvent on this path, Quickview included.
+        $pageletEvent = new GuestWishlistPageletLoadedEvent(new GuestWishlistPagelet(), $salesChannelContext, new Request());
+        $withPageletEvent = $payPalExpressCheckoutDataService->buildExpressCheckoutButtonData($salesChannelContext, true, $pageletEvent);
+
+        foreach ([$withoutEvent, $withPageletEvent] as $expressCheckoutButtonData) {
+            static::assertNotNull($expressCheckoutButtonData);
+            static::assertSame($expectedFundingSources, $expressCheckoutButtonData->getFundingSources());
+            static::assertSame($showPayLaterSetting, $expressCheckoutButtonData->isShowPayLater());
+        }
+    }
+
+    public static function dataProviderTestFundingSourcesWithoutProductContext(): array
+    {
+        return [
+            'PayLater enabled, no product context' => [true, ['paypal', 'paylater', 'venmo']],
+            'PayLater disabled, no product context' => [false, ['paypal', 'venmo']],
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The "Pay Later" express button never appears on listing pages, search results or CMS pages. `showPayLater()` returned `false` whenever no `AvailabilityContext` could be built, and those surfaces have no single product to build one from. Merchants cannot fix this from the admin — both relevant settings are already on.

### 2. What does this change do, exactly?

`showPayLater()` now checks the `ecsShowPayLater` setting first, then returns `true` when the context is `null` instead of `false`. The PayPal SDK's own per-buyer eligibility check then decides whether the button renders — the same check that already governs the product detail page. Known inconsistency: the detail page still evaluates `PAYPAL_PAY_LATER_CRITERIA`, so a product outside the amount bounds shows the button on a listing but not on its own detail page; PayPal declines the terms in its popup either way.

### 3. Describe each step to reproduce the issue or behaviour.

Enable "'PayPal Checkout' on listing pages" and "Display 'Pay Later' button", then create a "Shop page" layout with a Product Slider and assign it to the Home category. Read `data-swag-pay-pal-express-button-options` on a product card: before, `fundingSources` is `["paypal","venmo"]` on the homepage but `["paypal","paylater","venmo"]` on a product detail page. After, all surfaces send `paylater`; also verified in the Quickview modal with SwagCmsExtensions 5.4.0.

### 4. Please link to the relevant issues (if any).

- closes shopware/shopware#19027

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

