### PR TITLE
fix(devops): download the extension artifact without unzipping it

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,9 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download zip
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ github.event.repository.name }}.zip
+          # The artifact is the extension zip itself, not an archive around it.
+          skip-decompress: true
 
       - name: Install shopware-cli
         uses: shopware/shopware-cli-action@v3
@@ -153,9 +155,11 @@ jobs:
           path: ${{ env.PLUGIN_PATH }}
 
       - name: Download zip
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: SwagPayPal.zip
+          # The artifact is the extension zip itself, not an archive around it.
+          skip-decompress: true
 
       - name: Setup SwagPayPal
         uses: ./paypal/.github/actions/setup-paypal


### PR DESCRIPTION
### 1. Why is this change necessary?

`shopware/github-actions/build-zip@main` changed today ([547ccb9](https://github.com/shopware/github-actions/commit/547ccb93), "avoid double-zipping build artifacts"): it now uploads the extension zip as the artifact itself rather than wrapping it in an artifact archive. Because we track that action on `@main`, every run since then fails `validate` with `cannot find path: .../SwagPayPal.zip`.

### 2. What does this change do, exactly?

The artifact is still served as `application/zip`, and `actions/download-artifact` unzips anything that looks like a zip — so the consuming jobs unpacked the plugin into a `SwagPayPal/` tree instead of writing `SwagPayPal.zip`. `v8` is the first version that can hand back a raw artifact, via `skip-decompress`. Both jobs that consume the zip are switched over.

The alternative was to pin `build-zip` to the pre-change commit, but the new upload shape is the one we want long-term — a zip inside a zip was only ever an artifact-format artifact.

### 3. Describe each step to reproduce the issue or behaviour.

`validate` is red on every open PR; it goes green here.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
