### PR TITLE
[6.5.x] fix(checkout): make PayPal transaction timestamp nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 8.12.2
+- Fixes an issue, where PayPal orders could not be placed when the `updated_at` column of the PayPal order transaction table was not nullable
 - Fixes an issue, where line item labels containing line breaks made the PayPal order creation fail for local payment methods like iDEAL, P24, EPS or Bancontact
 
 # 8.12.1

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,5 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 8.12.2
+- Behebt ein Problem, bei dem PayPal-Bestellungen nicht abgeschlossen werden konnten, wenn die `updated_at`-Spalte der PayPal-Bestelltransaktionstabelle keine NULL-Werte zuließ
 - Behebt ein Problem, bei dem Positionsbezeichnungen mit Zeilenumbrüchen die Erstellung der PayPal-Bestellung für lokale Zahlungsarten wie iDEAL, P24, EPS oder Bancontact fehlschlagen ließen
 
 # 8.12.1

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "8.12.1",
+    "version": "8.12.2",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullable.php
+++ b/src/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullable.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class Migration1787895934MakeOrderTransactionsUpdatedAtNullable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1787895934;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $schemaManager = $connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist(['swag_paypal_order_transactions'])) {
+            return;
+        }
+
+        if (!$this->columnExists($connection, 'swag_paypal_order_transactions', 'updated_at')) {
+            return;
+        }
+
+        $connection->executeStatement(
+            'ALTER TABLE `swag_paypal_order_transactions` MODIFY COLUMN `updated_at` DATETIME(3) NULL'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/tests/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest.php
+++ b/tests/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Swag\PayPal\Migration\Migration1786431500OrderTransactions;
 use Swag\PayPal\Migration\Migration1787895934MakeOrderTransactionsUpdatedAtNullable;
 
 /**
@@ -25,8 +26,10 @@ class Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest extends Test
     {
         $connection = KernelLifecycleManager::getConnection();
         $connection->executeStatement('DROP TABLE IF EXISTS `swag_paypal_order_transactions`');
+
+        (new Migration1786431500OrderTransactions())->update($connection);
         $connection->executeStatement(
-            'CREATE TABLE `swag_paypal_order_transactions` (`updated_at` DATETIME(3) NOT NULL)'
+            'ALTER TABLE `swag_paypal_order_transactions` MODIFY COLUMN `updated_at` DATETIME(3) NOT NULL'
         );
 
         $migration = new Migration1787895934MakeOrderTransactionsUpdatedAtNullable();

--- a/tests/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest.php
+++ b/tests/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swag\PayPal\Test\Migration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Swag\PayPal\Migration\Migration1787895934MakeOrderTransactionsUpdatedAtNullable;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1787895934MakeOrderTransactionsUpdatedAtNullable::class)]
+class Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest extends TestCase
+{
+    public function testMakesUpdatedAtNullableIdempotently(): void
+    {
+        $connection = KernelLifecycleManager::getConnection();
+        $connection->executeStatement('DROP TABLE IF EXISTS `swag_paypal_order_transactions`');
+        $connection->executeStatement(
+            'CREATE TABLE `swag_paypal_order_transactions` (`updated_at` DATETIME(3) NOT NULL)'
+        );
+
+        $migration = new Migration1787895934MakeOrderTransactionsUpdatedAtNullable();
+        $migration->update($connection);
+        $migration->update($connection);
+
+        $column = $connection->fetchAssociative(
+            'SHOW COLUMNS FROM `swag_paypal_order_transactions` WHERE `Field` = \'updated_at\''
+        );
+
+        static::assertIsArray($column);
+        static::assertSame('YES', $column['Null']);
+    }
+}

--- a/tests/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest.php
+++ b/tests/Migration/Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest.php
@@ -8,7 +8,6 @@
 
 namespace Swag\PayPal\Test\Migration;
 
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -19,7 +18,6 @@ use Swag\PayPal\Migration\Migration1787895934MakeOrderTransactionsUpdatedAtNulla
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(Migration1787895934MakeOrderTransactionsUpdatedAtNullable::class)]
 class Migration1787895934MakeOrderTransactionsUpdatedAtNullableTest extends TestCase
 {
     public function testMakesUpdatedAtNullableIdempotently(): void


### PR DESCRIPTION
The `swag_paypal_order_transactions.updated_at` column may be created as `NOT NULL`, causing PayPal order inserts to fail.
This migration ensures the column is nullable for existing installations.

- backport https://github.com/shopware/SwagPayPal/pull/793