### PR TITLE
fix(checkout): handle partial entities in the express checkout listing subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixes an issue, where a custom tax provider's adjusted total was not charged, because the PayPal order used the stale cart or order transaction amount instead of the taxed total (shopware/SwagPayPal#722)
 - Fixes an issue, where PayPal shipping tracking sync retried 429 RATE_LIMIT_REACHED responses too early instead of respecting the Retry-After header.
 - Fixes an issue, where the extension card context menu showed a raw snippet key instead of "Configure" (shopware/shopware#19028)
+- Fixes an issue, where product searches that load only a subset of fields, like the storefront quantity selector's purchase limit request, failed with an error, if the Express Checkout button was enabled for product listings (shopware/SwagPayPal#554)
 
 # 10.8.0
 - Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Fixes an issue, where product searches that load only a subset of fields, like the storefront quantity selector's purchase limit request, failed with an error, if the Express Checkout button was enabled for product listings (shopware/SwagPayPal#554)
+
 # 10.8.2
 - Fixes an issue, where PayPal orders could not be placed when the `updated_at` column of the PayPal order transaction table was not nullable
 - Fixes an issue, where line item labels containing line breaks made the PayPal order creation fail for local payment methods like iDEAL, P24, EPS or Bancontact
@@ -8,7 +11,6 @@
 - Fixes an issue, where PayPal Express Checkout buttons disappeared after using the browser back button from the checkout page (shopware/shopware#18297)
 - Fixes an issue, where PayPal shipping tracking sync retried 429 RATE_LIMIT_REACHED responses too early instead of respecting the Retry-After header.
 - Fixes an issue, where the extension card context menu showed a raw snippet key instead of "Configure" (shopware/shopware#19028)
-- Fixes an issue, where product searches that load only a subset of fields, like the storefront quantity selector's purchase limit request, failed with an error, if the Express Checkout button was enabled for product listings (shopware/SwagPayPal#554)
 
 # 10.8.0
 - Fixes an issue, where the PayPal Express Checkout failed without customer feedback when shipping to a country that is not assigned to the sales channel (shopware/shopware#15067)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+- Behebt ein Problem, bei dem Produktsuchen, die nur einen Teil der Felder laden (z. B. die Anfrage der Mengenauswahl zur Kaufmengenbegrenzung in der Storefront), mit einem Fehler fehlschlugen, wenn der Express-Checkout-Button für Produktlisten aktiviert war (shopware/SwagPayPal#554)
+
 # 10.8.2
 - Behebt ein Problem, bei dem PayPal-Bestellungen nicht abgeschlossen werden konnten, wenn die `updated_at`-Spalte der PayPal-Bestelltransaktionstabelle keine NULL-Werte zuließ
 - Behebt ein Problem, bei dem Positionsbezeichnungen mit Zeilenumbrüchen die Erstellung der PayPal-Bestellung für lokale Zahlungsarten wie iDEAL, P24, EPS oder Bancontact fehlschlagen ließen
@@ -8,7 +11,6 @@
 - Behebt ein Problem, bei dem die PayPal Express Checkout Buttons nach dem Zurücknavigieren vom Checkout mit dem Browser-Zurück-Button nicht mehr angezeigt wurden (shopware/shopware#18297)
 - Behebt ein Problem, bei dem die PayPal-Versandtracking-Synchronisierung 429 RATE_LIMIT_REACHED-Antworten zu früh erneut verarbeitet hat, anstatt den Retry-After-Header zu berücksichtigen.
 - Behebt ein Problem, bei dem im Kontextmenü der Erweiterungs-Kachel der rohe Snippet-Key statt „Konfigurieren” angezeigt wurde (shopware/shopware#19028)
-- Behebt ein Problem, bei dem Produktsuchen, die nur einen Teil der Felder laden (z. B. die Anfrage der Mengenauswahl zur Kaufmengenbegrenzung in der Storefront), mit einem Fehler fehlschlugen, wenn der Express-Checkout-Button für Produktlisten aktiviert war (shopware/SwagPayPal#554)
 
 # 10.8.0
 - Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -2,6 +2,7 @@
 - Behebt ein Problem, bei dem der von einem benutzerdefinierten Tax Provider angepasste Gesamtbetrag nicht berechnet wurde, weil die PayPal-Bestellung den veralteten Warenkorb- oder Bestelltransaktionsbetrag anstelle des besteuerten Gesamtbetrags verwendete (shopware/SwagPayPal#722)
 - Behebt ein Problem, bei dem die PayPal-Versandtracking-Synchronisierung 429 RATE_LIMIT_REACHED-Antworten zu früh erneut verarbeitet hat, anstatt den Retry-After-Header zu berücksichtigen.
 - Behebt ein Problem, bei dem im Kontextmenü der Erweiterungs-Kachel der rohe Snippet-Key statt „Konfigurieren” angezeigt wurde (shopware/shopware#19028)
+- Behebt ein Problem, bei dem Produktsuchen, die nur einen Teil der Felder laden (z. B. die Anfrage der Mengenauswahl zur Kaufmengenbegrenzung in der Storefront), mit einem Fehler fehlschlugen, wenn der Express-Checkout-Button für Produktlisten aktiviert war (shopware/SwagPayPal#554)
 
 # 10.8.0
 - Behebt ein Problem, bei dem der PayPal Express Checkout ohne Rückmeldung für den Kunden fehlschlug, wenn in ein Land geliefert werden sollte, das dem Verkaufskanal nicht zugeordnet ist (shopware/shopware#15067)

--- a/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
+++ b/src/Checkout/ExpressCheckout/ExpressCheckoutSubscriber.php
@@ -12,7 +12,8 @@ use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEvents;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent;
-use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\Event\DataMappingEvent;
@@ -171,7 +172,7 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param SalesChannelEntitySearchResultLoadedEvent<ProductCollection> $event
+     * @param SalesChannelEntitySearchResultLoadedEvent<EntityCollection<Entity>> $event
      */
     public function addExcludedProductsToSearchResult(SalesChannelEntitySearchResultLoadedEvent $event): void
     {
@@ -182,14 +183,15 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
         $productIds = [];
         $products = $event->getResult()->getEntities();
         foreach ($products as $product) {
-            $productIds[] = $product->getId();
-            $productIds[] = $product->getParentId();
+            foreach ($this->getProductIds($product) as $productId) {
+                $productIds[$productId] = $productId;
+            }
         }
 
-        $excluded = $this->excludedProductValidator->findExcludedProducts(\array_filter($productIds), $event->getSalesChannelContext());
+        $excluded = $this->excludedProductValidator->findExcludedProducts(\array_values($productIds), $event->getSalesChannelContext());
 
         foreach ($products as $product) {
-            if (\in_array($product->getId(), $excluded, true) || ($product->getParentId() && \in_array($product->getParentId(), $excluded, true))) {
+            if (\array_intersect($this->getProductIds($product), $excluded) !== []) {
                 $product->addExtension(ExcludedProductValidator::PRODUCT_EXCLUDED_FOR_PAYPAL, new ArrayStruct());
             }
         }
@@ -358,5 +360,30 @@ class ExpressCheckoutSubscriber implements EventSubscriberInterface
             default:
                 return false;
         }
+    }
+
+    /**
+     * The entities of a search result are `PartialEntity` instances, if the criteria limited the loaded
+     * fields via `Criteria::addFields()`. Those have no typed getters, therefore the ids are read via
+     * `has()`/`get()`, which works for partial as well as fully hydrated products.
+     *
+     * @return list<string>
+     */
+    private function getProductIds(Entity $product): array
+    {
+        $productIds = [];
+
+        foreach (['id', 'parentId'] as $field) {
+            if (!$product->has($field)) {
+                continue;
+            }
+
+            $productId = $product->get($field);
+            if (\is_string($productId) && $productId !== '') {
+                $productIds[] = $productId;
+            }
+        }
+
+        return $productIds;
     }
 }

--- a/tests/Checkout/Cart/ExcludedProductValidatorTest.php
+++ b/tests/Checkout/Cart/ExcludedProductValidatorTest.php
@@ -13,9 +13,11 @@ use Shopware\Core\Content\Product\DataAbstractionLayer\ProductStreamUpdater;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Swag\PayPal\Checkout\Cart\Service\ExcludedProductValidator;
@@ -148,6 +150,8 @@ class ExcludedProductValidatorTest extends TestCase
     #[DataProvider('dataProviderConstellations')]
     public function testExcludedProductTaggedInSearchResults(?string $settingKey, ?string $settingIdName, ?string $expectedIdName): void
     {
+        $this->enableExpressCheckoutForListings();
+
         if ($settingKey && $settingIdName) {
             $this->systemConfig->set($settingKey, [$this->idsCollection->get($settingIdName)]);
         }
@@ -160,9 +164,10 @@ class ExcludedProductValidatorTest extends TestCase
         static::assertInstanceOf(SalesChannelProductCollection::class, $products);
         static::assertNotEmpty($products);
 
+        // the searched variant is excluded, whenever it is excluded itself or through its parent
         foreach ($products as $product) {
             static::assertSame(
-                $product->getId() === $expectedIdName,
+                $expectedIdName !== null,
                 $product->hasExtension(ExcludedProductValidator::PRODUCT_EXCLUDED_FOR_PAYPAL)
             );
         }
@@ -174,6 +179,8 @@ class ExcludedProductValidatorTest extends TestCase
     #[DataProvider('dataProviderConstellations')]
     public function testExcludedProductTaggedInSearchResultsWithListingDisabled(?string $settingKey, ?string $settingIdName, ?string $_expectedIdName): void
     {
+        $this->enableExpressCheckoutForListings();
+
         if ($settingKey && $settingIdName) {
             $this->systemConfig->set($settingKey, [$this->idsCollection->get($settingIdName)]);
         }
@@ -189,6 +196,44 @@ class ExcludedProductValidatorTest extends TestCase
         foreach ($products as $product) {
             static::assertFalse($product->hasExtension(ExcludedProductValidator::PRODUCT_EXCLUDED_FOR_PAYPAL));
         }
+    }
+
+    /**
+     * this test is related to the ExpressCheckoutSubscriber
+     */
+    public function testExcludedProductTaggedInPartialSearchResults(): void
+    {
+        $this->enableExpressCheckoutForListings();
+        $this->systemConfig->set(Settings::EXCLUDED_PRODUCT_IDS, [$this->idsCollection->get('parent')]);
+
+        $variant = $this->searchPartialVariant(['parentId'], $this->registerUser());
+
+        static::assertTrue($variant->hasExtension(ExcludedProductValidator::PRODUCT_EXCLUDED_FOR_PAYPAL));
+    }
+
+    /**
+     * this test is related to the ExpressCheckoutSubscriber
+     */
+    public function testExcludedProductTaggedInPartialSearchResultsWithoutParentId(): void
+    {
+        $this->enableExpressCheckoutForListings();
+        $context = $this->registerUser();
+
+        // the field selection of Shopware\Core\Content\Product\SalesChannel\PurchaseLimit\ProductPurchaseLimitRoute
+        $fields = ['minPurchase', 'maxPurchase', 'purchaseSteps', 'isCloseout', 'stock'];
+
+        // without the parentId, an exclusion through the parent product cannot be detected anymore
+        $this->systemConfig->set(Settings::EXCLUDED_PRODUCT_IDS, [$this->idsCollection->get('parent')]);
+        $variant = $this->searchPartialVariant($fields, $context);
+
+        static::assertFalse($variant->has('parentId'));
+        static::assertFalse($variant->hasExtension(ExcludedProductValidator::PRODUCT_EXCLUDED_FOR_PAYPAL));
+
+        // the product's own id is always loaded, as it is the primary key
+        $this->systemConfig->set(Settings::EXCLUDED_PRODUCT_IDS, [$this->idsCollection->get('variant')]);
+        $variant = $this->searchPartialVariant($fields, $context);
+
+        static::assertTrue($variant->hasExtension(ExcludedProductValidator::PRODUCT_EXCLUDED_FOR_PAYPAL));
     }
 
     public static function dataProviderConstellations(): array
@@ -220,5 +265,49 @@ class ExcludedProductValidatorTest extends TestCase
                 'parent',
             ],
         ];
+    }
+
+    /**
+     * The ExpressCheckoutSubscriber only tags excluded products in search results, if the express
+     * checkout is actually shown on listing pages.
+     */
+    private function enableExpressCheckoutForListings(): void
+    {
+        $this->systemConfig->set(Settings::CLIENT_ID, 'someClientId');
+        $this->systemConfig->set(Settings::CLIENT_SECRET, 'someClientSecret');
+        $this->systemConfig->set(Settings::ECS_LISTING_ENABLED, true);
+
+        $paymentMethodUtil = $this->getContainer()->get(PaymentMethodUtil::class);
+        $paymentMethodId = $paymentMethodUtil->getPayPalPaymentMethodId(Context::createDefaultContext());
+        static::assertNotNull($paymentMethodId);
+
+        $this->getContainer()->get('payment_method.repository')->update([[
+            'id' => $paymentMethodId,
+            'active' => true,
+        ]], Context::createDefaultContext());
+        $this->addPaymentMethodToDefaultsSalesChannel($paymentMethodId);
+
+        $paymentMethodUtil->reset();
+    }
+
+    /**
+     * Criteria::addFields() makes the DAL hydrate PartialEntity instances, which only carry the
+     * requested fields and have no typed getters.
+     *
+     * @param list<string> $fields
+     */
+    private function searchPartialVariant(array $fields, SalesChannelContext $context): PartialEntity
+    {
+        $criteria = new Criteria([$this->idsCollection->get('variant')]);
+        $criteria->addFields($fields);
+
+        $variant = $this->getContainer()->get('sales_channel.product.repository')
+            ->search($criteria, $context)
+            ->getEntities()
+            ->get($this->idsCollection->get('variant'));
+
+        static::assertInstanceOf(PartialEntity::class, $variant);
+
+        return $variant;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

`ExpressCheckoutSubscriber::addExcludedProductsToSearchResult()` listens to
`sales_channel.product.search.result.loaded`, which is dispatched for *every* sales-channel product
search — including those that narrow the loaded fields with `Criteria::addFields()`. Such reads hydrate
`PartialEntity` instances, which carry no typed getters, so `$product->getParentId()` is a fatal error.
The `@param …<ProductCollection>` docblock is what kept this hidden: the runtime collection is never a
`ProductCollection`.

Third-party plugins are not the only trigger — core's `store-api.product.purchase-limit` route, used by
the storefront quantity selector on closeout products, reads products with `addFields()` and without
`parentId`.

### 2. What does this change do, exactly?

The handler no longer assumes a typed product entity: ids are read through `Entity::has()` /
`Entity::get()`, the way core's `ProductSubscriber` handles possibly-partial products, and the event's
generic becomes `EntityCollection<Entity>` so static analysis stops offering getters that may not exist.

One consequence is deliberate. When a partial read does not request `parentId`, an exclusion inherited
from the parent product can no longer be detected and the product is not tagged; resolving that would
mean an extra query on every partial product read, defeating the reason callers use `addFields()`.
Exclusions by a product's own id keep working, because the primary key is always loaded.

The two existing tests labelled "related to the ExpressCheckoutSubscriber" never reached the handler —
no credentials, no active payment method, listing disabled — and their assertion compared a UUID against
an ids-collection name. Repairing them is what makes the new regression tests bite.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure PayPal credentials and enable "PayPal Checkout on listing pages".
2. Trigger a sales-channel product search that uses `Criteria::addFields()` — for instance change the
   quantity on the detail page of a closeout product, which calls the purchase-limit route.
3. Before this change: `Call to undefined method PartialEntity::getParentId()`.

The new tests in `ExcludedProductValidatorTest` reproduce this through a plain
`sales_channel.product.repository` search.

### 4. Please link to the relevant issues (if any).

closes #554

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
