### PR TITLE
fix(checkout): preserve paid transactions from stale cancellations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 10.8.2
+- Fixes an issue, where late PayPal cancellation responses or webhooks could change a successfully paid transaction to cancelled (shopware/shopware#19221)
 - Fixes an issue, where PayPal orders could not be placed when the `updated_at` column of the PayPal order transaction table was not nullable
 - Fixes an issue, where line item labels containing line breaks made the PayPal order creation fail for local payment methods like iDEAL, P24, EPS or Bancontact
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,5 @@
 # 10.8.2
+- Behebt ein Problem, bei dem verspätete PayPal-Abbruchantworten oder Webhooks eine erfolgreich bezahlte Transaktion auf „Abgebrochen“ setzen konnten (shopware/shopware#19221)
 - Behebt ein Problem, bei dem PayPal-Bestellungen nicht abgeschlossen werden konnten, wenn die `updated_at`-Spalte der PayPal-Bestelltransaktionstabelle keine NULL-Werte zuließ
 - Behebt ein Problem, bei dem Positionsbezeichnungen mit Zeilenumbrüchen die Erstellung der PayPal-Bestellung für lokale Zahlungsarten wie iDEAL, P24, EPS oder Bancontact fehlschlagen ließen
 

--- a/src/Checkout/Payment/Method/AbstractPaymentMethodHandler.php
+++ b/src/Checkout/Payment/Method/AbstractPaymentMethodHandler.php
@@ -9,6 +9,7 @@ namespace Swag\PayPal\Checkout\Payment\Method;
 
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AbstractPaymentHandler;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PaymentHandlerType;
@@ -44,6 +45,11 @@ abstract class AbstractPaymentMethodHandler extends AbstractPaymentHandler
 {
     public const PAYPAL_PAYMENT_ORDER_ID_INPUT_NAME = 'paypalOrderId';
     public const PAYPAL_REQUEST_PARAMETER_CANCEL = 'cancel';
+
+    private const FINALIZED_TRANSACTION_STATES = [
+        OrderTransactionStates::STATE_PAID,
+        OrderTransactionStates::STATE_AUTHORIZED,
+    ];
 
     /**
      * @internal
@@ -145,6 +151,10 @@ abstract class AbstractPaymentMethodHandler extends AbstractPaymentHandler
         Context $context,
     ): void {
         [$orderTransaction, $order] = $this->fetchOrderTransaction($transaction->getOrderTransactionId(), $context);
+
+        if ($this->isTransactionFinalized($orderTransaction)) {
+            return;
+        }
 
         $paypalOrderId = $orderTransaction->getCustomFieldsValue(SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_ORDER_ID);
         if (!\is_string($paypalOrderId) || !$paypalOrderId) {
@@ -274,12 +284,20 @@ abstract class AbstractPaymentMethodHandler extends AbstractPaymentHandler
         return $order?->getLinks()->getRelation(Link::RELATION_PAYER_ACTION)?->getHref();
     }
 
+    private function isTransactionFinalized(OrderTransactionEntity $orderTransaction): bool
+    {
+        $state = $orderTransaction->getStateMachineState()?->getTechnicalName();
+
+        return $state !== null && \in_array($state, self::FINALIZED_TRANSACTION_STATES, true);
+    }
+
     /**
      * @return array{0: OrderTransactionEntity, 1: OrderEntity}
      */
     private function fetchOrderTransaction(string $transactionId, Context $context): array
     {
         $criteria = new Criteria([$transactionId]);
+        $criteria->addAssociation('stateMachineState');
         $criteria->addAssociation('order.billingAddress.country');
         $criteria->addAssociation('order.billingAddress.countryState');
         $criteria->addAssociation('order.currency');

--- a/src/Webhook/Handler/AbstractWebhookHandler.php
+++ b/src/Webhook/Handler/AbstractWebhookHandler.php
@@ -10,6 +10,7 @@ namespace Swag\PayPal\Webhook\Handler;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -57,6 +58,7 @@ abstract class AbstractWebhookHandler implements WebhookHandler
 
         $criteria = new Criteria();
         $criteria->addAssociation('order');
+        $criteria->addAssociation('stateMachineState');
         $criteria->addFilter(
             new EqualsFilter(
                 \sprintf('customFields.%s', SwagPayPal::ORDER_TRANSACTION_CUSTOM_FIELDS_PAYPAL_TRANSACTION_ID),
@@ -120,5 +122,15 @@ abstract class AbstractWebhookHandler implements WebhookHandler
         }
 
         return $state->getTechnicalName() !== $invalidStatus;
+    }
+
+    protected function isCancellationAllowed(OrderTransactionEntity $orderTransaction): bool
+    {
+        $state = $orderTransaction->getStateMachineState()?->getTechnicalName();
+
+        return $state === null || !\in_array($state, [
+            OrderTransactionStates::STATE_CANCELLED,
+            OrderTransactionStates::STATE_PAID,
+        ], true);
     }
 }

--- a/src/Webhook/Handler/AuthorizationVoided.php
+++ b/src/Webhook/Handler/AuthorizationVoided.php
@@ -7,7 +7,6 @@
 
 namespace Swag\PayPal\Webhook\Handler;
 
-use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Event;
@@ -47,7 +46,7 @@ class AuthorizationVoided extends AbstractWebhookHandler
             }
         }
 
-        if ($this->isChangeAllowed($orderTransaction, OrderTransactionStates::STATE_CANCELLED)) {
+        if ($this->isCancellationAllowed($orderTransaction)) {
             $this->orderTransactionStateHandler->cancel($orderTransaction->getId(), $context);
         }
     }

--- a/src/Webhook/Handler/CaptureDenied.php
+++ b/src/Webhook/Handler/CaptureDenied.php
@@ -7,7 +7,6 @@
 
 namespace Swag\PayPal\Webhook\Handler;
 
-use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Event;
@@ -31,7 +30,7 @@ class CaptureDenied extends AbstractWebhookHandler
         }
         $orderTransaction = $this->getOrderTransactionV2($capture, $context);
 
-        if ($this->isChangeAllowed($orderTransaction, OrderTransactionStates::STATE_CANCELLED)) {
+        if ($this->isCancellationAllowed($orderTransaction)) {
             $this->orderTransactionStateHandler->cancel($orderTransaction->getId(), $context);
         }
     }

--- a/src/Webhook/Handler/SaleDenied.php
+++ b/src/Webhook/Handler/SaleDenied.php
@@ -7,7 +7,6 @@
 
 namespace Swag\PayPal\Webhook\Handler;
 
-use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Event;
@@ -31,7 +30,7 @@ class SaleDenied extends AbstractWebhookHandler
 
         $orderTransaction = $this->getOrderTransaction($webhook->getResource(), $context);
 
-        if ($this->isChangeAllowed($orderTransaction, OrderTransactionStates::STATE_CANCELLED)) {
+        if ($this->isCancellationAllowed($orderTransaction)) {
             $this->orderTransactionStateHandler->cancel($orderTransaction->getId(), $context);
         }
     }

--- a/tests/Checkout/Payment/PayPalPaymentHandlerTest.php
+++ b/tests/Checkout/Payment/PayPalPaymentHandlerTest.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Test\Checkout\Payment;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
@@ -218,6 +219,27 @@ class PayPalPaymentHandlerTest extends TestCase
             new PaymentTransactionStruct($this->getTransactionId(Context::createDefaultContext(), $this->getContainer())),
             Context::createDefaultContext(),
         );
+    }
+
+    #[DataProvider('finalizedTransactionStateProvider')]
+    public function testFinalizeWithCancelLeavesFinalizedTransactionUnchanged(string $state): void
+    {
+        $context = Context::createDefaultContext();
+        $transactionId = $this->getTransactionId($context, $this->getContainer(), $state);
+
+        $this->createPayPalPaymentHandler()->finalize(
+            new Request([PayPalPaymentHandler::PAYPAL_REQUEST_PARAMETER_CANCEL => true]),
+            new PaymentTransactionStruct($transactionId),
+            $context,
+        );
+
+        $this->assertOrderTransactionState($state, $transactionId, $context);
+    }
+
+    public static function finalizedTransactionStateProvider(): \Generator
+    {
+        yield 'paid transaction' => [OrderTransactionStates::STATE_PAID];
+        yield 'authorized transaction' => [OrderTransactionStates::STATE_AUTHORIZED];
     }
 
     public function testFinalizePayPalOrderCapture(): void

--- a/tests/Webhook/Handler/AuthorizationVoidedV2Test.php
+++ b/tests/Webhook/Handler/AuthorizationVoidedV2Test.php
@@ -113,6 +113,12 @@ class AuthorizationVoidedV2Test extends AbstractWebhookHandlerTestCase
         $this->assertInvoke(OrderTransactionStates::STATE_CANCELLED, $webhook, OrderTransactionStates::STATE_CANCELLED);
     }
 
+    public function testInvokeDoesNotCancelPaidTransaction(): void
+    {
+        $webhook = $this->createWebhookV2(Event::RESOURCE_TYPE_AUTHORIZATION);
+        $this->assertInvoke(OrderTransactionStates::STATE_PAID, $webhook, OrderTransactionStates::STATE_PAID);
+    }
+
     protected function createWebhookHandler(): AuthorizationVoided
     {
         return new AuthorizationVoided(

--- a/tests/Webhook/Handler/CaptureDeniedTest.php
+++ b/tests/Webhook/Handler/CaptureDeniedTest.php
@@ -56,6 +56,12 @@ class CaptureDeniedTest extends AbstractWebhookHandlerTestCase
         $this->assertInvoke(OrderTransactionStates::STATE_CANCELLED, $webhook, OrderTransactionStates::STATE_CANCELLED);
     }
 
+    public function testInvokeDoesNotCancelPaidTransaction(): void
+    {
+        $webhook = $this->createWebhookV2(Event::RESOURCE_TYPE_CAPTURE);
+        $this->assertInvoke(OrderTransactionStates::STATE_PAID, $webhook, OrderTransactionStates::STATE_PAID);
+    }
+
     protected function createWebhookHandler()
     {
         return new CaptureDenied(

--- a/tests/Webhook/Handler/SaleDeniedTest.php
+++ b/tests/Webhook/Handler/SaleDeniedTest.php
@@ -49,6 +49,12 @@ class SaleDeniedTest extends AbstractWebhookHandlerTestCase
         $this->assertInvoke(OrderTransactionStates::STATE_CANCELLED, $webhook, OrderTransactionStates::STATE_CANCELLED);
     }
 
+    public function testInvokeDoesNotCancelPaidTransaction(): void
+    {
+        $webhook = $this->createWebhookV1();
+        $this->assertInvoke(OrderTransactionStates::STATE_PAID, $webhook, OrderTransactionStates::STATE_PAID);
+    }
+
     protected function createWebhookHandler(): SaleDenied
     {
         return new SaleDenied(


### PR DESCRIPTION
### 1. Why is this change necessary?

Late PayPal cancellation callbacks or negative webhooks can change an already paid transaction to `cancelled`.

### 2. What does this change do, exactly?

Keep paid transactions unchanged for these inputs, and treat authorized transactions as finalized for browser callbacks. Also load transaction state for v1 webhooks and add regression tests.

### 3. Describe each step to reproduce the issue or behaviour.

1. Complete a PayPal payment so its transaction is `paid`.
2. Invoke the finalize URL with `cancel=1`, or send a matching negative webhook.
3. The transaction previously became `cancelled`; it now remains `paid`.

### 4. Please link to the relevant issues (if any).

- closes shopware/shopware#19221

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
