### PR TITLE
fix(checkout): run update steps exactly once by tracking them in the system config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue, where product searches that load only a subset of fields, like the storefront quantity selector's purchase limit request, failed with an error, if the Express Checkout button was enabled for product listings (shopware/SwagPayPal#554)
+- Fixes an issue, where all plugin update steps ran again and reset settings, when the installed plugin version was a non-comparable composer branch version. Executed update steps are now tracked in the system config and run exactly once
 
 # 10.8.2
 - Fixes an issue, where PayPal orders could not be placed when the `updated_at` column of the PayPal order transaction table was not nullable

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem Produktsuchen, die nur einen Teil der Felder laden (z. B. die Anfrage der Mengenauswahl zur Kaufmengenbegrenzung in der Storefront), mit einem Fehler fehlschlugen, wenn der Express-Checkout-Button für Produktlisten aktiviert war (shopware/SwagPayPal#554)
+- Behebt ein Problem, bei dem alle Plugin-Update-Schritte erneut ausgeführt wurden und Einstellungen zurücksetzten, wenn die installierte Plugin-Version eine nicht vergleichbare Composer-Branch-Version war. Ausgeführte Update-Schritte werden jetzt in der Systemkonfiguration nachgehalten und genau einmal ausgeführt
 
 # 10.8.2
 - Behebt ein Problem, bei dem PayPal-Bestellungen nicht abgeschlossen werden konnten, wenn die `updated_at`-Spalte der PayPal-Bestelltransaktionstabelle keine NULL-Werte zuließ

--- a/src/Util/Lifecycle/Update.php
+++ b/src/Util/Lifecycle/Update.php
@@ -78,20 +78,24 @@ class Update
 
     public function update(UpdateContext $updateContext): void
     {
-        $executedSteps = $this->getExecutedUpdateSteps();
         $currentVersion = $updateContext->getCurrentPluginVersion();
 
         // Non-semver versions (e.g. composer branch versions like "dev-some-branch") cannot be compared to the
-        // step versions, so all steps are only marked as executed, but not run: skipping a step is recoverable
-        // on the next update, re-running a destructive one is not.
-        $isComparableVersion = \preg_match('/^\d+\.\d+/', $currentVersion) === 1;
+        // step versions, so the true baseline is unknown: no steps are run, since re-running a destructive step
+        // is not recoverable, and deliberately none are recorded as executed either, so pending steps still run
+        // once the version has been corrected to a comparable one.
+        if (\preg_match('/^\d+\.\d+/', $currentVersion) !== 1) {
+            return;
+        }
+
+        $executedSteps = $this->getExecutedUpdateSteps();
 
         foreach ($this->getUpdateSteps($updateContext->getContext()) as $version => $step) {
             if (\in_array($version, $executedSteps, true)) {
                 continue;
             }
 
-            if ($isComparableVersion && \version_compare($currentVersion, $version, '<')) {
+            if (\version_compare($currentVersion, $version, '<')) {
                 $step();
             }
 

--- a/src/Util/Lifecycle/Update.php
+++ b/src/Util/Lifecycle/Update.php
@@ -58,6 +58,8 @@ class Update
 {
     use PosSalesChannelTrait;
 
+    public const EXECUTED_UPDATE_STEPS_CONFIG_KEY = Settings::SYSTEM_CONFIG_DOMAIN . 'executedUpdateSteps';
+
     public function __construct(
         private readonly SystemConfigService $systemConfig,
         private readonly EntityRepository $paymentRepository,
@@ -76,93 +78,72 @@ class Update
 
     public function update(UpdateContext $updateContext): void
     {
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '1.3.0', '<')) {
-            $this->updateTo130();
+        $executedSteps = $this->getExecutedUpdateSteps();
+        $currentVersion = $updateContext->getCurrentPluginVersion();
+
+        // Non-semver versions (e.g. composer branch versions like "dev-some-branch") cannot be compared to the
+        // step versions, so all steps are only marked as executed, but not run: skipping a step is recoverable
+        // on the next update, re-running a destructive one is not.
+        $isComparableVersion = \preg_match('/^\d+\.\d+/', $currentVersion) === 1;
+
+        foreach ($this->getUpdateSteps($updateContext->getContext()) as $version => $step) {
+            if (\in_array($version, $executedSteps, true)) {
+                continue;
+            }
+
+            if ($isComparableVersion && \version_compare($currentVersion, $version, '<')) {
+                $step();
+            }
+
+            $executedSteps[] = $version;
+            // persist after every step, so an interrupted update does not re-run already executed steps
+            $this->systemConfig->set(self::EXECUTED_UPDATE_STEPS_CONFIG_KEY, $executedSteps);
+        }
+    }
+
+    /**
+     * @return array<string, callable(): void>
+     */
+    private function getUpdateSteps(Context $context): array
+    {
+        return [
+            '1.3.0' => fn () => $this->updateTo130(),
+            '1.7.0' => fn () => $this->updateTo170(),
+            '1.7.2' => fn () => $this->updateTo172($context),
+            '2.0.0' => fn () => $this->updateTo200($context),
+            '3.0.0' => fn () => $this->updateTo300($context),
+            '5.0.0' => fn () => $this->updateTo500($context),
+            '5.3.0' => fn () => $this->updateTo530($context),
+            '5.3.1' => fn () => $this->updateTo531($context),
+            '5.4.0' => fn () => $this->updateTo540($context),
+            '5.4.6' => fn () => $this->updateTo546($context),
+            '6.0.0' => fn () => $this->updateTo600($context),
+            '6.2.0' => fn () => $this->updateTo620(),
+            '7.3.0' => fn () => $this->updateTo730(),
+            '9.0.0' => fn () => $this->updateTo900($context),
+            '9.0.2' => fn () => $this->updateTo902($context),
+            '9.1.0' => fn () => $this->updateTo910($context),
+            '9.2.0' => fn () => $this->updateTo920($context),
+            '9.3.1' => fn () => $this->updateTo931($context),
+            '9.6.1' => fn () => $this->updateTo961($context),
+            '10.4.0' => fn () => $this->updateTo1040($context),
+            '10.6.0' => fn () => $this->updateTo1060(),
+            '10.7.0' => fn () => $this->updateTo1070(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getExecutedUpdateSteps(): array
+    {
+        $executedSteps = $this->systemConfig->get(self::EXECUTED_UPDATE_STEPS_CONFIG_KEY);
+
+        if (!\is_array($executedSteps)) {
+            return [];
         }
 
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '1.7.0', '<')) {
-            $this->updateTo170();
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '1.7.2', '<')) {
-            $this->updateTo172($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '2.0.0', '<')) {
-            $this->updateTo200($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '3.0.0', '<')) {
-            $this->updateTo300($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '5.0.0', '<')) {
-            $this->updateTo500($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '5.3.0', '<')) {
-            $this->updateTo530($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '5.3.1', '<')) {
-            $this->updateTo531($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '5.4.0', '<')) {
-            $this->updateTo540($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '5.4.6', '<')) {
-            $this->updateTo546($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '6.0.0', '<')) {
-            $this->updateTo600($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '6.2.0', '<')) {
-            $this->updateTo620();
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '7.3.0', '<')) {
-            $this->updateTo730();
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '9.0.0', '<')) {
-            $this->updateTo900($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '9.0.2', '<')) {
-            $this->updateTo902($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '9.1.0', '<')) {
-            $this->updateTo910($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '9.2.0', '<')) {
-            $this->updateTo920($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '9.3.1', '<')) {
-            $this->updateTo931($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '9.6.1', '<')) {
-            $this->updateTo961($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '10.4.0', '<')) {
-            $this->updateTo1040($updateContext->getContext());
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '10.6.0', '<')) {
-            $this->updateTo1060();
-        }
-
-        if (\version_compare($updateContext->getCurrentPluginVersion(), '10.7.0', '<')) {
-            $this->updateTo1070();
-        }
+        return \array_values(\array_filter($executedSteps, \is_string(...)));
     }
 
     private function updateTo130(): void

--- a/tests/Util/Lifecycle/UpdateTest.php
+++ b/tests/Util/Lifecycle/UpdateTest.php
@@ -102,7 +102,7 @@ class UpdateTest extends TestCase
         $this->salesChannelRepository = $this->getRepository(SalesChannelDefinition::ENTITY_NAME);
     }
 
-    public function testUpdateWithNonComparableVersionRunsNoSteps(): void
+    public function testUpdateWithNonComparableVersionRunsAndRecordsNoSteps(): void
     {
         $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
         // mirrors the state that triggered the incident: a landing page value that is only valid since 9.0.2
@@ -117,10 +117,23 @@ class UpdateTest extends TestCase
         static::assertSame(ExperienceContext::LANDING_PAGE_TYPE_GUEST, $systemConfigService->get(Settings::LANDING_PAGE));
         static::assertTrue($systemConfigService->get(Settings::ACDC_FORCE_3DS));
 
-        $executedSteps = $systemConfigService->get(Update::EXECUTED_UPDATE_STEPS_CONFIG_KEY);
-        static::assertIsArray($executedSteps);
-        static::assertContains('2.0.0', $executedSteps);
-        static::assertContains('10.7.0', $executedSteps);
+        // nothing is recorded either: the baseline is unknown, so the steps must still be able to run
+        // once the plugin version has been corrected to a comparable one
+        static::assertNull($systemConfigService->get(Update::EXECUTED_UPDATE_STEPS_CONFIG_KEY));
+    }
+
+    public function testUpdateRunsPendingStepsAfterNonComparableVersionWasCorrected(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfigService->set(Settings::ECS_SHIPPING_CALLBACK_ENABLED, false);
+        $update = $this->createUpdateService($systemConfigService);
+
+        $update->update($this->createUpdateContext('dev-codex/some-branch', '10.8.3'));
+        static::assertFalse($systemConfigService->get(Settings::ECS_SHIPPING_CALLBACK_ENABLED));
+
+        // the plugin version got corrected to the version the branch was based on, pending steps now run
+        $update->update($this->createUpdateContext('10.5.0', '10.8.3'));
+        static::assertTrue($systemConfigService->get(Settings::ECS_SHIPPING_CALLBACK_ENABLED));
     }
 
     public function testUpdateRunsEachStepOnlyOnce(): void

--- a/tests/Util/Lifecycle/UpdateTest.php
+++ b/tests/Util/Lifecycle/UpdateTest.php
@@ -102,6 +102,74 @@ class UpdateTest extends TestCase
         $this->salesChannelRepository = $this->getRepository(SalesChannelDefinition::ENTITY_NAME);
     }
 
+    public function testUpdateWithNonComparableVersionRunsNoSteps(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        // mirrors the state that triggered the incident: a landing page value that is only valid since 9.0.2
+        // together with a composer branch version, which every step's version_compare considers older than anything
+        $systemConfigService->set(Settings::LANDING_PAGE, ExperienceContext::LANDING_PAGE_TYPE_GUEST);
+        $systemConfigService->set(Settings::ACDC_FORCE_3DS, true);
+
+        $updateContext = $this->createUpdateContext('dev-codex/some-branch', '10.8.3');
+        $update = $this->createUpdateService($systemConfigService);
+        $update->update($updateContext);
+
+        static::assertSame(ExperienceContext::LANDING_PAGE_TYPE_GUEST, $systemConfigService->get(Settings::LANDING_PAGE));
+        static::assertTrue($systemConfigService->get(Settings::ACDC_FORCE_3DS));
+
+        $executedSteps = $systemConfigService->get(Update::EXECUTED_UPDATE_STEPS_CONFIG_KEY);
+        static::assertIsArray($executedSteps);
+        static::assertContains('2.0.0', $executedSteps);
+        static::assertContains('10.7.0', $executedSteps);
+    }
+
+    public function testUpdateRunsEachStepOnlyOnce(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $updateContext = $this->createUpdateContext('10.5.0', '10.8.0');
+        $update = $this->createUpdateService($systemConfigService);
+
+        $update->update($updateContext);
+        static::assertTrue($systemConfigService->get(Settings::ECS_SHIPPING_CALLBACK_ENABLED));
+
+        // the merchant changes the setting afterwards, a repeated update must not overwrite it again
+        $systemConfigService->set(Settings::ECS_SHIPPING_CALLBACK_ENABLED, false);
+        $update->update($updateContext);
+        static::assertFalse($systemConfigService->get(Settings::ECS_SHIPPING_CALLBACK_ENABLED));
+    }
+
+    public function testUpdateSeedsExecutedStepsFromCurrentVersion(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $update = $this->createUpdateService($systemConfigService);
+        $update->update($this->createUpdateContext('10.5.0', '10.8.0'));
+
+        $executedSteps = $systemConfigService->get(Update::EXECUTED_UPDATE_STEPS_CONFIG_KEY);
+        static::assertIsArray($executedSteps);
+        // steps below the current version are marked as executed without running
+        static::assertContains('1.3.0', $executedSteps);
+        static::assertContains('10.4.0', $executedSteps);
+        // steps above the current version ran and are marked as executed
+        static::assertContains('10.6.0', $executedSteps);
+        static::assertContains('10.7.0', $executedSteps);
+    }
+
+    public function testUpdateSkipsStepsAlreadyMarkedAsExecuted(): void
+    {
+        $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfigService->set(Update::EXECUTED_UPDATE_STEPS_CONFIG_KEY, ['10.6.0']);
+        $systemConfigService->set(Settings::ECS_SHIPPING_CALLBACK_ENABLED, false);
+        $systemConfigService->set(Settings::INSTALLMENT_BANNER_TEXT_SIZE, 14);
+
+        $update = $this->createUpdateService($systemConfigService);
+        $update->update($this->createUpdateContext('10.5.0', '10.8.0'));
+
+        // 10.6.0 is marked as executed and must not run again
+        static::assertFalse($systemConfigService->get(Settings::ECS_SHIPPING_CALLBACK_ENABLED));
+        // 10.7.0 is not marked and must still run
+        static::assertSame(12, $systemConfigService->get(Settings::INSTALLMENT_BANNER_TEXT_SIZE));
+    }
+
     public function testUpdateTo130WithNoPreviousSettings(): void
     {
         $systemConfigService = SystemConfigServiceMock::createWithoutCredentials();


### PR DESCRIPTION
### 1. Why is this change necessary?

The update steps in `Util/Lifecycle/Update.php` are gated only by `version_compare` against the currently installed version. When that version is not a comparable semver — e.g. a composer branch version like `dev-bugfix` written to the plugin table (see shopware/shopware#20007) — every comparison evaluates to `true` and **all** update steps run again. On SaaS this reset merchant settings (e.g. `acdcForce3DS`) and crashed in `migrateLandingPageSetting` on values that only exist in newer versions.

### 2. What does this change do, exactly?

Executed update steps are now tracked in the system config (`SwagPayPal.settings.executedUpdateSteps`) and run exactly once:

- Steps at or below the current version are seeded as executed without running (no migration needed for existing installations).
- If the current version is not comparable, no steps run and none are recorded: re-running a destructive step is not recoverable, while the skipped steps still run once the plugin version has been corrected to a comparable one (e.g. by the SaaS UpdateManager migration).
- The list is persisted after every step, so an interrupted update resumes where it stopped instead of losing the remaining steps.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install SwagPayPal so that the `plugin` table contains a non-semver version (e.g. require it as `dev-some-branch as 10.8.1` — the alias is dropped, fixed separately in shopware/shopware#20007).
2. Configure a landing page setting introduced after 9.0.2 (e.g. `GUEST_CHECKOUT`) or set `acdcForce3DS` to `true`.
3. Update the plugin: previously all update steps ran again, resetting settings and throwing `Invalid value for "SwagPayPal.settings.landingPage" setting`.

### 4. Please link to the relevant issues (if any).

- relates shopware/shopware#20007 (root cause: composer inline aliases not resolved for plugin versions)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
  - Note: the new tests are integration tests and could not be executed in my local checkout; the incident test provably fails on the previous code (it throws `Invalid value for "SwagPayPal.settings.landingPage" setting`), but please let CI confirm.
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
