### PR TITLE
[6.6.x] fix(lifecycle): preserve settings during custom version updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 9.13.2
+- Fixes an issue where updating from a custom plugin version could rerun migrations, overwrite existing PayPal configuration values, or fail because of legacy landing page settings
 - Fixes an issue, where PayPal orders could not be placed when the `updated_at` column of the PayPal order transaction table was not nullable
 - Fixes an issue, where line item labels containing line breaks made the PayPal order creation fail for local payment methods like iDEAL, P24, EPS or Bancontact
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 9.13.2
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Fixes an issue where updating from a custom plugin version could rerun migrations, overwrite existing PayPal configuration values, or fail because of legacy landing page settings
+
+# 9.13.2
 - Fixes an issue, where PayPal orders could not be placed when the `updated_at` column of the PayPal order transaction table was not nullable
 - Fixes an issue, where line item labels containing line breaks made the PayPal order creation fail for local payment methods like iDEAL, P24, EPS or Bancontact
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,7 @@
-# 9.13.2
+# REPLACE_GLOBALLY_WITH_NEXT_VERSION
 - Behebt ein Problem, bei dem ein Update von einer benutzerdefinierten Plugin-Version Migrationen erneut ausführen, vorhandene PayPal-Konfigurationswerte überschreiben oder wegen veralteter Landing-Page-Einstellungen fehlschlagen konnte
+
+# 9.13.2
 - Behebt ein Problem, bei dem PayPal-Bestellungen nicht abgeschlossen werden konnten, wenn die `updated_at`-Spalte der PayPal-Bestelltransaktionstabelle keine NULL-Werte zuließ
 - Behebt ein Problem, bei dem Positionsbezeichnungen mit Zeilenumbrüchen die Erstellung der PayPal-Bestellung für lokale Zahlungsarten wie iDEAL, P24, EPS oder Bancontact fehlschlagen ließen
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,5 @@
 # 9.13.2
+- Behebt ein Problem, bei dem ein Update von einer benutzerdefinierten Plugin-Version Migrationen erneut ausführen, vorhandene PayPal-Konfigurationswerte überschreiben oder wegen veralteter Landing-Page-Einstellungen fehlschlagen konnte
 - Behebt ein Problem, bei dem PayPal-Bestellungen nicht abgeschlossen werden konnten, wenn die `updated_at`-Spalte der PayPal-Bestelltransaktionstabelle keine NULL-Werte zuließ
 - Behebt ein Problem, bei dem Positionsbezeichnungen mit Zeilenumbrüchen die Erstellung der PayPal-Bestellung für lokale Zahlungsarten wie iDEAL, P24, EPS oder Bancontact fehlschlagen ließen
 

--- a/src/Setting/Settings.php
+++ b/src/Setting/Settings.php
@@ -8,7 +8,7 @@
 namespace Swag\PayPal\Setting;
 
 use Shopware\Core\Framework\Log\Package;
-use Swag\PayPal\RestApi\V2\Api\Order\ApplicationContext;
+use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Common\ExperienceContext;
 use Swag\PayPal\RestApi\V2\PaymentIntentV2;
 
 #[Package('checkout')]
@@ -86,7 +86,7 @@ final class Settings
         self::SANDBOX => false,
         self::INTENT => PaymentIntentV2::CAPTURE,
         self::SUBMIT_CART => true,
-        self::LANDING_PAGE => ApplicationContext::LANDING_PAGE_TYPE_NO_PREFERENCE,
+        self::LANDING_PAGE => ExperienceContext::LANDING_PAGE_TYPE_NO_PREFERENCE,
         self::SEND_ORDER_NUMBER => true,
         self::MERCHANT_LOCATION => self::MERCHANT_LOCATION_OTHER,
         self::ECS_DETAIL_ENABLED => true,

--- a/src/Util/Lifecycle/Update.php
+++ b/src/Util/Lifecycle/Update.php
@@ -76,6 +76,11 @@ class Update
 
     public function update(UpdateContext $updateContext): void
     {
+        // Development branches have no reliable migration order.
+        if (!\preg_match('/^\d+(?:\.\d+)*$/', $updateContext->getCurrentPluginVersion())) {
+            return;
+        }
+
         if (\version_compare($updateContext->getCurrentPluginVersion(), '1.3.0', '<')) {
             $this->updateTo130();
         }
@@ -429,7 +434,13 @@ class Update
                 continue;
             }
 
-            if (\in_array($landingPage, ApplicationContext::LANDING_PAGE_TYPES, true)) {
+            if (\in_array($landingPage, ExperienceContext::LANDING_PAGE_TYPES, true)) {
+                continue;
+            }
+
+            if ($landingPage === ApplicationContextV2::LANDING_PAGE_TYPE_BILLING) {
+                $this->systemConfig->set(Settings::LANDING_PAGE, ExperienceContext::LANDING_PAGE_TYPE_GUEST, $salesChannelId);
+
                 continue;
             }
 
@@ -438,12 +449,12 @@ class Update
             }
 
             if ($landingPage === ApplicationContextV1::LANDING_PAGE_TYPE_LOGIN) {
-                $this->systemConfig->set(Settings::LANDING_PAGE, ApplicationContextV2::LANDING_PAGE_TYPE_LOGIN, $salesChannelId);
+                $this->systemConfig->set(Settings::LANDING_PAGE, ExperienceContext::LANDING_PAGE_TYPE_LOGIN, $salesChannelId);
 
                 continue;
             }
 
-            $this->systemConfig->set(Settings::LANDING_PAGE, ApplicationContextV2::LANDING_PAGE_TYPE_BILLING, $salesChannelId);
+            $this->systemConfig->set(Settings::LANDING_PAGE, ExperienceContext::LANDING_PAGE_TYPE_GUEST, $salesChannelId);
         }
     }
 
@@ -455,8 +466,12 @@ class Update
         return $salesChannelIds;
     }
 
-    private function setSettingToDefaultValue(string $setting, ?string $overrideValue = null, ?string $salesChannelId = null): void
+    private function setSettingToDefaultValue(string $setting, mixed $overrideValue = null, ?string $salesChannelId = null): void
     {
+        if ($this->systemConfig->get($setting, $salesChannelId) !== null) {
+            return;
+        }
+
         $value = Settings::DEFAULT_VALUES[$setting] ?? null;
         $this->systemConfig->set($setting, $overrideValue ?? $value, $salesChannelId);
     }
@@ -485,11 +500,11 @@ class Update
     {
         $installmentBannerEnabled = $this->systemConfig->getBool(Settings::SYSTEM_CONFIG_DOMAIN . 'installmentBannerEnabled');
 
-        $this->systemConfig->set(Settings::INSTALLMENT_BANNER_DETAIL_PAGE_ENABLED, $installmentBannerEnabled);
-        $this->systemConfig->set(Settings::INSTALLMENT_BANNER_CART_ENABLED, $installmentBannerEnabled);
-        $this->systemConfig->set(Settings::INSTALLMENT_BANNER_OFF_CANVAS_CART_ENABLED, $installmentBannerEnabled);
-        $this->systemConfig->set(Settings::INSTALLMENT_BANNER_LOGIN_PAGE_ENABLED, $installmentBannerEnabled);
-        $this->systemConfig->set(Settings::INSTALLMENT_BANNER_FOOTER_ENABLED, $installmentBannerEnabled);
+        $this->setSettingToDefaultValue(Settings::INSTALLMENT_BANNER_DETAIL_PAGE_ENABLED, $installmentBannerEnabled);
+        $this->setSettingToDefaultValue(Settings::INSTALLMENT_BANNER_CART_ENABLED, $installmentBannerEnabled);
+        $this->setSettingToDefaultValue(Settings::INSTALLMENT_BANNER_OFF_CANVAS_CART_ENABLED, $installmentBannerEnabled);
+        $this->setSettingToDefaultValue(Settings::INSTALLMENT_BANNER_LOGIN_PAGE_ENABLED, $installmentBannerEnabled);
+        $this->setSettingToDefaultValue(Settings::INSTALLMENT_BANNER_FOOTER_ENABLED, $installmentBannerEnabled);
     }
 
     private function updateTo900(Context $context): void
@@ -587,6 +602,6 @@ class Update
 
     private function updateTo1060(): void
     {
-        $this->systemConfig->set(Settings::ECS_SHIPPING_CALLBACK_ENABLED, true);
+        $this->setSettingToDefaultValue(Settings::ECS_SHIPPING_CALLBACK_ENABLED, true);
     }
 }

--- a/src/Util/Lifecycle/Update.php
+++ b/src/Util/Lifecycle/Update.php
@@ -30,7 +30,6 @@ use Swag\PayPal\Pos\Webhook\Exception\WebhookNotRegisteredException;
 use Swag\PayPal\Pos\Webhook\WebhookService as PosWebhookService;
 use Swag\PayPal\RestApi\V1\Api\Payment\ApplicationContext as ApplicationContextV1;
 use Swag\PayPal\RestApi\V1\PaymentIntentV1;
-use Swag\PayPal\RestApi\V2\Api\Order\ApplicationContext;
 use Swag\PayPal\RestApi\V2\Api\Order\ApplicationContext as ApplicationContextV2;
 use Swag\PayPal\RestApi\V2\Api\Order\PaymentSource\Common\ExperienceContext;
 use Swag\PayPal\RestApi\V2\PaymentIntentV2;

--- a/tests/Util/Lifecycle/UpdateTest.php
+++ b/tests/Util/Lifecycle/UpdateTest.php
@@ -7,6 +7,7 @@
 
 namespace Swag\PayPal\Test\Util\Lifecycle;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
@@ -260,6 +261,83 @@ class UpdateTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid value for "SwagPayPal.settings.intent" setting');
         $updater->update($updateContext);
+    }
+
+    #[DataProvider('existingSettingsProvider')]
+    public function testUpdateKeepsExistingSettingValue(string $currentVersion, string $nextVersion, string $setting, mixed $value): void
+    {
+        $updateContext = $this->createUpdateContext($currentVersion, $nextVersion);
+        $systemConfig = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfig->set($setting, $value);
+
+        $updater = $this->createUpdateService($systemConfig);
+        $updater->update($updateContext);
+
+        static::assertSame($value, $systemConfig->get($setting));
+    }
+
+    public static function existingSettingsProvider(): \Generator
+    {
+        yield 'PUI instructions' => ['4.9.0', '5.0.0', Settings::PUI_CUSTOMER_SERVICE_INSTRUCTIONS, 'Existing instructions'];
+        yield '3D Secure' => ['5.3.1', '5.4.0', Settings::ACDC_FORCE_3DS, true];
+        yield 'express checkout pay later' => ['6.1.0', '6.2.0', Settings::ECS_SHOW_PAY_LATER, false];
+        yield 'installment banner product detail page' => ['7.2.0', '7.3.0', Settings::INSTALLMENT_BANNER_DETAIL_PAGE_ENABLED, false];
+        yield 'installment banner cart' => ['7.2.0', '7.3.0', Settings::INSTALLMENT_BANNER_CART_ENABLED, false];
+        yield 'installment banner off-canvas cart' => ['7.2.0', '7.3.0', Settings::INSTALLMENT_BANNER_OFF_CANVAS_CART_ENABLED, false];
+        yield 'installment banner login page' => ['7.2.0', '7.3.0', Settings::INSTALLMENT_BANNER_LOGIN_PAGE_ENABLED, false];
+        yield 'installment banner footer' => ['7.2.0', '7.3.0', Settings::INSTALLMENT_BANNER_FOOTER_ENABLED, false];
+        yield 'express checkout shipping callback' => ['10.5.0', '10.6.0', Settings::ECS_SHIPPING_CALLBACK_ENABLED, false];
+    }
+
+    public function testUpdateSkipsNonNumericCurrentPluginVersion(): void
+    {
+        $updateContext = $this->createUpdateContext('dev-trunk', '10.8.10');
+        $systemConfig = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfig->set(Settings::CLIENT_ID, self::CLIENT_ID);
+        $systemConfig->set(Settings::CLIENT_SECRET, self::CLIENT_SECRET);
+        $systemConfig->delete(Settings::CLIENT_ID_SANDBOX);
+        $systemConfig->delete(Settings::CLIENT_SECRET_SANDBOX);
+        $systemConfig->set(Settings::SANDBOX, true);
+
+        $updater = $this->createUpdateService($systemConfig);
+        $updater->update($updateContext);
+
+        static::assertSame(self::CLIENT_ID, $systemConfig->get(Settings::CLIENT_ID));
+        static::assertSame(self::CLIENT_SECRET, $systemConfig->get(Settings::CLIENT_SECRET));
+        static::assertNull($systemConfig->get(Settings::CLIENT_ID_SANDBOX));
+        static::assertNull($systemConfig->get(Settings::CLIENT_SECRET_SANDBOX));
+    }
+
+    public function testUpdateRunsUpdatesWithNonNumericTargetPluginVersion(): void
+    {
+        $updateContext = $this->createUpdateContext('9.0.1', 'dev-trunk');
+        $systemConfig = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfig->set(Settings::LANDING_PAGE, ApplicationContextV2::LANDING_PAGE_TYPE_BILLING, TestDefaults::SALES_CHANNEL);
+
+        $updater = $this->createUpdateService($systemConfig);
+        $updater->update($updateContext);
+
+        static::assertSame(ExperienceContext::LANDING_PAGE_TYPE_GUEST, $systemConfig->get(Settings::LANDING_PAGE, TestDefaults::SALES_CHANNEL, false));
+    }
+
+    #[DataProvider('currentLandingPageValuesProvider')]
+    public function testUpdateTo200KeepsCurrentLandingPageValue(string $landingPage): void
+    {
+        $updateContext = $this->createUpdateContext('1.9.1', '2.0.0');
+        $systemConfig = SystemConfigServiceMock::createWithoutCredentials();
+        $systemConfig->set(Settings::LANDING_PAGE, $landingPage, TestDefaults::SALES_CHANNEL);
+
+        $updater = $this->createUpdateService($systemConfig);
+        $updater->update($updateContext);
+
+        static::assertSame($landingPage, $systemConfig->get(Settings::LANDING_PAGE, TestDefaults::SALES_CHANNEL, false));
+    }
+
+    public static function currentLandingPageValuesProvider(): \Generator
+    {
+        yield 'login' => [ExperienceContext::LANDING_PAGE_TYPE_LOGIN];
+        yield 'guest checkout' => [ExperienceContext::LANDING_PAGE_TYPE_GUEST];
+        yield 'no preference' => [ExperienceContext::LANDING_PAGE_TYPE_NO_PREFERENCE];
     }
 
     public function testUpdateTo200MigrateIntentSettingWithInvalidLandingPage(): void

--- a/tests/Util/Lifecycle/UpdateTest.php
+++ b/tests/Util/Lifecycle/UpdateTest.php
@@ -291,7 +291,7 @@ class UpdateTest extends TestCase
 
     public function testUpdateSkipsNonNumericCurrentPluginVersion(): void
     {
-        $updateContext = $this->createUpdateContext('dev-trunk', '10.8.10');
+        $updateContext = $this->createUpdateContext('dev-trunk', '9.13.2');
         $systemConfig = SystemConfigServiceMock::createWithoutCredentials();
         $systemConfig->set(Settings::CLIENT_ID, self::CLIENT_ID);
         $systemConfig->set(Settings::CLIENT_SECRET, self::CLIENT_SECRET);


### PR DESCRIPTION
### 1. Why is this change necessary?

Updating from a custom, non-numeric plugin version could rerun migrations, overwrite existing PayPal configuration values, or reject legacy landing-page settings.

### 2. What does this change do, exactly?

Skips migrations for non-numeric custom plugin versions, preserves existing configuration values, and migrates legacy landing-page values to their current equivalents.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install the plugin from a custom branch with a non-numeric version, for example `dev-trunk`.
2. Configure PayPal settings such as `ACDC_FORCE_3DS = false` or a legacy landing-page value.
3. Update the plugin to a released version.

### 4. Please link to the relevant issues (if any).

- Backport of #802

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.