### PR TITLE
feat(administration): add PayPal Businesskredit partner offer banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 10.8.3
 - Fixes an issue, where product searches that load only a subset of fields, like the storefront quantity selector's purchase limit request, failed with an error, if the Express Checkout button was enabled for product listings (shopware/SwagPayPal#554)
 
 # 10.8.2

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,4 +1,4 @@
-# REPLACE_GLOBALLY_WITH_NEXT_VERSION
+# 10.8.3
 - Behebt ein Problem, bei dem Produktsuchen, die nur einen Teil der Felder laden (z. B. die Anfrage der Mengenauswahl zur Kaufmengenbegrenzung in der Storefront), mit einem Fehler fehlschlugen, wenn der Express-Checkout-Button für Produktlisten aktiviert war (shopware/SwagPayPal#554)
 
 # 10.8.2

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "swag/paypal",
     "description": "PayPal integration for Shopware 6",
-    "version": "10.8.2",
+    "version": "10.8.3",
     "type": "shopware-platform-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/index.ts
@@ -1,0 +1,54 @@
+import template from './swag-paypal-method-partner-offer.html.twig';
+import './swag-paypal-method-partner-offer.scss';
+
+const HIDDEN_STORAGE_KEY = 'swag-paypal-businesskredit-offer-hidden';
+
+/**
+ * The offer runs until the end of 2026-12-31 in the merchant's local time.
+ */
+const OFFER_END = new Date(2027, 0, 1).getTime();
+
+/**
+ * Both the banner copy and the landing page behind it are German only,
+ * so the offer is limited to merchants working in a German administration.
+ */
+const OFFER_LANGUAGE = 'de';
+
+export default Shopware.Component.wrapComponentConfig({
+    template,
+
+    data(): {
+        hidden: boolean;
+    } {
+        return {
+            hidden: localStorage.getItem(HIDDEN_STORAGE_KEY) === 'true',
+        };
+    },
+
+    computed: {
+        offerLink(): string {
+            return 'https://www.shopware.com/de/paypal-businesskredit';
+        },
+
+        isOfferRunning(): boolean {
+            return Date.now() < OFFER_END;
+        },
+
+        isGermanMerchant(): boolean {
+            const locale = Shopware.Store.get('session').currentLocale;
+
+            return locale?.split('-')[0] === OFFER_LANGUAGE;
+        },
+
+        show(): boolean {
+            return !this.hidden && this.isOfferRunning && this.isGermanMerchant;
+        },
+    },
+
+    methods: {
+        onCloseBanner() {
+            this.hidden = true;
+            localStorage.setItem(HIDDEN_STORAGE_KEY, 'true');
+        },
+    },
+});

--- a/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/swag-paypal-method-partner-offer.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/swag-paypal-method-partner-offer.html.twig
@@ -1,0 +1,24 @@
+<mt-banner
+    v-if="show"
+    class="swag-paypal-method-partner-offer"
+    variant="info"
+    :title="$t('swag-paypal-method.partnerOffer.title')"
+    :hide-icon="true"
+    :closable="true"
+    @close="onCloseBanner"
+>
+    <p class="swag-paypal-method-partner-offer__disclaimer">
+        {{ $t('swag-paypal-method.partnerOffer.disclaimer') }}
+    </p>
+
+    <mt-link
+        class="swag-paypal-method-partner-offer__link"
+        type="external"
+        as="a"
+        target="_blank"
+        rel="noopener noreferrer"
+        :href="offerLink"
+    >
+        {{ $t('swag-paypal-method.partnerOffer.link') }}
+    </mt-link>
+</mt-banner>

--- a/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/swag-paypal-method-partner-offer.scss
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/swag-paypal-method-partner-offer.scss
@@ -1,0 +1,16 @@
+.swag-paypal-method-partner-offer {
+    /* mt-banner centers itself on its own width, the card content is full width */
+    width: 100%;
+    margin: 0;
+
+    .mt-banner__message {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--scale-size-8);
+    }
+
+    &__disclaimer {
+        margin: 0;
+    }
+}

--- a/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/swag-paypal-method-partner-offer.spec.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/component/swag-paypal-method-partner-offer/swag-paypal-method-partner-offer.spec.ts
@@ -1,0 +1,100 @@
+import { mount } from '@vue/test-utils';
+import SwagPayPalMethodPartnerOffer from '.';
+
+Shopware.Component.register('swag-paypal-method-partner-offer', Promise.resolve(SwagPayPalMethodPartnerOffer));
+
+async function createWrapper() {
+    return mount(
+        await Shopware.Component.build('swag-paypal-method-partner-offer') as typeof SwagPayPalMethodPartnerOffer,
+        {
+            global: {
+                stubs: {
+                    'mt-link': { template: '<a :href="$attrs.href"><slot></slot></a>' },
+                },
+            },
+        },
+    );
+}
+
+describe('swag-paypal-method-partner-offer', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        Shopware.Store.get('session').currentLocale = 'de-DE';
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date(2026, 8, 3));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should be a Vue.js component', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('should show while the offer is running', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.show).toBe(true);
+        expect(wrapper.find('.swag-paypal-method-partner-offer').exists()).toBe(true);
+    });
+
+    it('should show on the last day of the offer', async () => {
+        jest.setSystemTime(new Date(2026, 11, 31, 23, 59, 59));
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.show).toBe(true);
+    });
+
+    it('should not show after the offer ended', async () => {
+        jest.setSystemTime(new Date(2027, 0, 1));
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.show).toBe(false);
+        expect(wrapper.find('.swag-paypal-method-partner-offer').exists()).toBe(false);
+    });
+
+    it.each([
+        'en-GB',
+        'nl-NL',
+        null,
+    ])('should not show for the locale %s', async (currentLocale) => {
+        Shopware.Store.get('session').currentLocale = currentLocale;
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.isGermanMerchant).toBe(false);
+        expect(wrapper.find('.swag-paypal-method-partner-offer').exists()).toBe(false);
+    });
+
+    it('should stay hidden once closed', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onCloseBanner();
+        await flushPromises();
+
+        expect(wrapper.vm.show).toBe(false);
+        expect(wrapper.find('.swag-paypal-method-partner-offer').exists()).toBe(false);
+        expect(localStorage.getItem('swag-paypal-businesskredit-offer-hidden')).toBe('true');
+    });
+
+    it('should not show when it was closed before', async () => {
+        localStorage.setItem('swag-paypal-businesskredit-offer-hidden', 'true');
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.show).toBe(false);
+    });
+
+    it('should link to the landing page', async () => {
+        const wrapper = await createWrapper();
+
+        const link = wrapper.find('a');
+        expect(link.exists()).toBe(true);
+        expect(link.attributes('href')).toBe('https://www.shopware.com/de/paypal-businesskredit');
+    });
+});

--- a/src/Resources/app/administration/src/module/swag-paypal-method/index.ts
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/index.ts
@@ -3,6 +3,7 @@ import { ui } from '@shopware-ag/meteor-admin-sdk';
 Shopware.Component.register('swag-paypal-method-domain-association', () => import('./component/swag-paypal-method-domain-association'));
 Shopware.Component.register('swag-paypal-method-merchant-information', () => import('./component/swag-paypal-method-merchant-information'));
 Shopware.Component.register('swag-paypal-payment-method', () => import('./component/swag-paypal-payment-method'));
+Shopware.Component.register('swag-paypal-method-partner-offer', () => import('./component/swag-paypal-method-partner-offer'));
 
 Shopware.Component.register('swag-paypal-method-card', () => import('./view/swag-paypal-method-card'));
 

--- a/src/Resources/app/administration/src/module/swag-paypal-method/snippet/de.json
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/snippet/de.json
@@ -21,6 +21,11 @@
       "title": "Bitte vergewissere dich, dass die Domain korrekt eingestellt ist, damit Apple Pay funktioniert. Die Domain-Zuordnungsdatei ist bereits hinterlegt.",
       "link": "Domain-Einstellungen öffnen"
     },
+    "partnerOffer": {
+      "title": "Partnerangebot - PayPal Businesskredit: Einfacher Kredit fürs Geschäft",
+      "disclaimer": "(Vorbehaltlich Kreditbewilligung*)",
+      "link": "Mehr erfahren"
+    },
     "paymentMethodText": "Zahlungsmöglichkeiten",
     "appImageAlt": "PayPal",
     "ratePayLabel": "von Ratepay",

--- a/src/Resources/app/administration/src/module/swag-paypal-method/snippet/en.json
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/snippet/en.json
@@ -21,6 +21,11 @@
       "title": "Please make sure your domain is set correctly for Apple Pay to work properly. The domain association file is already present.",
       "link": "Open domains settings"
     },
+    "partnerOffer": {
+      "title": "Partnerangebot - PayPal Businesskredit: Einfacher Kredit fürs Geschäft",
+      "disclaimer": "(Vorbehaltlich Kreditbewilligung*)",
+      "link": "Mehr erfahren"
+    },
     "paymentMethodText": "Payment methods",
     "appImageAlt": "PayPal",
     "ratePayLabel": "by Ratepay",

--- a/src/Resources/app/administration/src/module/swag-paypal-method/view/swag-paypal-method-card/swag-paypal-method-card.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal-method/view/swag-paypal-method-card/swag-paypal-method-card.html.twig
@@ -91,6 +91,10 @@
             </div>
         </template>
 
+        {% block swag_paypal_method_card_partner_offer %}
+        <swag-paypal-method-partner-offer />
+        {% endblock %}
+
         {% block swag_paypal_method_card_payment_methods %}
         <p class="swag-paypal-method-card__payment-method-headline">
             {{ $t('swag-paypal-method.paymentMethodText') }}


### PR DESCRIPTION
### 1. Why is this change necessary?

PayPal has approved a Businesskredit partner offer that runs until the end of 2026 and should be advertised to merchants in the payment settings.

### 2. What does this change do, exactly?

Adds a `swag-paypal-method-partner-offer` component — an `mt-banner` per Kristina's design — to the PayPal card in the payment settings, between the merchant information and the payment method listing.

The banner is a time-boxed advertisement, so all three of its visibility rules live in the component itself rather than in configuration: it hides itself after 2026-12-31 when the offer ends, it only renders for German administrations, and merchants can dismiss it (remembered per browser, like the neighbouring domain-association banner).

The German-only restriction is keyed on the admin locale's language. The merchant information the module already loads has no country anywhere in it — neither `merchantIntegrations` nor the SDK's `MerchantIntegrations` struct carries one — so a true "German merchant" check would need a new PayPal call. Locale is the better proxy anyway, since what actually binds here is that the approved copy and the landing page exist only in German.

### 3. Describe each step to reproduce the issue or behaviour.

Open Settings → Payment methods with a German administration language. The banner appears in the PayPal card above the payment method list, and "Mehr erfahren" opens https://www.shopware.com/de/paypal-businesskredit.

### 4. Please link to the relevant issues (if any).

- closes #786

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

No changelog entry: this is a time-boxed advertisement, not a product change.

The copy is used verbatim from the ticket, including the mandatory asterisk after "Vorbehaltlich Kreditbewilligung" — PayPal approved that exact wording, so please do not reword it. Note the placement deviates from the Figma file, which puts the banner at the top of the card; it sits below the merchant information here by request.
