### PR TITLE
fix(checkout): mock the cart load route in the taxed cart tests

### DIFF
--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressCreateOrderRouteTaxedCartTest.php
@@ -19,10 +19,10 @@ use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartLoadRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
-use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartResponse;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
-use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -52,12 +52,6 @@ class ExpressCreateOrderRouteTaxedCartTest extends TestCase
         $cart = new Cart('express-token');
         $cart->add(new LineItem('test', LineItem::PRODUCT_LINE_ITEM_TYPE, 'test'));
 
-        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
-        $taxProviderProcessor
-            ->expects($this->once())
-            ->method('process')
-            ->with($cart, $salesChannelContext);
-
         $cartPriceService = $this->createMock(CartPriceService::class);
         $cartPriceService
             ->expects($this->once())
@@ -66,7 +60,7 @@ class ExpressCreateOrderRouteTaxedCartTest extends TestCase
             ->willThrowException(new OrderZeroValueException());
 
         $route = new ExpressCreateOrderRoute(
-            $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),
+            $this->createTaxedCartService($cart, $salesChannelContext),
             $this->createMock(PayPalOrderBuilder::class),
             $this->createMock(OrderResource::class),
             $cartPriceService,
@@ -83,32 +77,27 @@ class ExpressCreateOrderRouteTaxedCartTest extends TestCase
     private function createTaxedCartService(
         Cart $cart,
         SalesChannelContext $salesChannelContext,
-        TaxProviderProcessor $taxProviderProcessor,
     ): CartService {
-        $persister = $this->createMock(AbstractCartPersister::class);
-        $persister
+        $cartLoadRoute = $this->createMock(AbstractCartLoadRoute::class);
+        $cartLoadRoute
             ->expects($this->once())
             ->method('load')
-            ->with($cart->getToken(), $salesChannelContext)
-            ->willReturn($cart);
+            ->with(
+                static::callback(static function (Request $request) use ($cart): bool {
+                    static::assertSame($cart->getToken(), $request->query->get('token'));
+                    static::assertTrue($request->query->getBoolean('taxed'));
 
-        $calculator = $this->createMock(CartCalculator::class);
-        $calculator
-            ->expects($this->once())
-            ->method('calculate')
-            ->with($cart, $salesChannelContext)
-            ->willReturn($cart);
+                    return true;
+                }),
+                $salesChannelContext,
+            )
+            ->willReturn(new CartResponse($cart));
 
         return new CartService(
-            $persister,
+            $this->createMock(AbstractCartPersister::class),
             $this->createMock(EventDispatcherInterface::class),
-            $calculator,
-            new CartLoadRoute(
-                $persister,
-                $this->createMock(CartFactory::class),
-                $calculator,
-                $taxProviderProcessor,
-            ),
+            $this->createMock(CartCalculator::class),
+            $cartLoadRoute,
             $this->createMock(AbstractCartDeleteRoute::class),
             $this->createMock(AbstractCartItemAddRoute::class),
             $this->createMock(AbstractCartItemUpdateRoute::class),

--- a/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/SalesChannel/ExpressPrepareCheckoutRouteTaxedCartTest.php
@@ -19,10 +19,10 @@ use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartLoadRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
-use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartResponse;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
-use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -56,12 +56,6 @@ class ExpressPrepareCheckoutRouteTaxedCartTest extends TestCase
         $newToken = 'new-context-token';
         $cart = new Cart($newToken);
         $cart->add(new LineItem('test', LineItem::PRODUCT_LINE_ITEM_TYPE, 'test'));
-
-        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
-        $taxProviderProcessor
-            ->expects($this->once())
-            ->method('process')
-            ->with($cart, $salesChannelContext);
 
         $newSalesChannelContext = $this->createMock(SalesChannelContext::class);
         $newSalesChannelContext
@@ -98,7 +92,7 @@ class ExpressPrepareCheckoutRouteTaxedCartTest extends TestCase
             $expressCustomerService,
             $salesChannelContextFactory,
             $orderResource,
-            $this->createTaxedCartService($cart, $salesChannelContext, $newSalesChannelContext, $taxProviderProcessor),
+            $this->createTaxedCartService($cart, $salesChannelContext, $newSalesChannelContext),
             $cartPriceService,
             new NullLogger(),
         );
@@ -118,14 +112,8 @@ class ExpressPrepareCheckoutRouteTaxedCartTest extends TestCase
         Cart $cart,
         SalesChannelContext $salesChannelContext,
         SalesChannelContext $newSalesChannelContext,
-        TaxProviderProcessor $taxProviderProcessor,
     ): CartService {
         $persister = $this->createMock(AbstractCartPersister::class);
-        $persister
-            ->expects($this->once())
-            ->method('load')
-            ->with($cart->getToken(), $salesChannelContext)
-            ->willReturn($cart);
         $persister
             ->expects($this->once())
             ->method('save')
@@ -133,20 +121,30 @@ class ExpressPrepareCheckoutRouteTaxedCartTest extends TestCase
 
         $calculator = $this->createMock(CartCalculator::class);
         $calculator
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('calculate')
             ->willReturn($cart);
+
+        $cartLoadRoute = $this->createMock(AbstractCartLoadRoute::class);
+        $cartLoadRoute
+            ->expects($this->once())
+            ->method('load')
+            ->with(
+                static::callback(static function (Request $request) use ($cart): bool {
+                    static::assertSame($cart->getToken(), $request->query->get('token'));
+                    static::assertTrue($request->query->getBoolean('taxed'));
+
+                    return true;
+                }),
+                $salesChannelContext,
+            )
+            ->willReturn(new CartResponse($cart));
 
         return new CartService(
             $persister,
             $this->createMock(EventDispatcherInterface::class),
             $calculator,
-            new CartLoadRoute(
-                $persister,
-                $this->createMock(CartFactory::class),
-                $calculator,
-                $taxProviderProcessor,
-            ),
+            $cartLoadRoute,
             $this->createMock(AbstractCartDeleteRoute::class),
             $this->createMock(AbstractCartItemAddRoute::class),
             $this->createMock(AbstractCartItemUpdateRoute::class),

--- a/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
+++ b/tests/Checkout/ExpressCheckout/Service/ExpressShippingCallbackServiceTaxedCartTest.php
@@ -19,10 +19,10 @@ use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartLoadRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
-use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartResponse;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
-use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\Log\Package;
@@ -45,6 +45,7 @@ use Swag\PayPal\Checkout\ExpressCheckout\Service\ExpressShippingCallbackService;
 use Swag\PayPal\OrdersApi\Builder\AbstractOrderBuilder;
 use Swag\PayPal\OrdersApi\Builder\Util\ShippingOptionsProvider;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -57,12 +58,6 @@ class ExpressShippingCallbackServiceTaxedCartTest extends TestCase
     {
         $salesChannelContext = $this->createSalesChannelContext();
         $cart = new Cart('shipping-token');
-
-        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
-        $taxProviderProcessor
-            ->expects($this->once())
-            ->method('process')
-            ->with($cart, $salesChannelContext);
 
         $order = new Order();
         $order->setPurchaseUnits(new PurchaseUnitCollection([new PurchaseUnit()]));
@@ -91,7 +86,7 @@ class ExpressShippingCallbackServiceTaxedCartTest extends TestCase
             ->willReturn($salesChannelContext->getShippingMethod());
 
         $service = new ExpressShippingCallbackService(
-            $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),
+            $this->createTaxedCartService($cart, $salesChannelContext),
             $this->createMock(SalesChannelRepository::class),
             $orderBuilder,
             $shippingOptionsProvider,
@@ -168,32 +163,27 @@ class ExpressShippingCallbackServiceTaxedCartTest extends TestCase
     private function createTaxedCartService(
         Cart $cart,
         SalesChannelContext $salesChannelContext,
-        TaxProviderProcessor $taxProviderProcessor,
     ): CartService {
-        $persister = $this->createMock(AbstractCartPersister::class);
-        $persister
+        $cartLoadRoute = $this->createMock(AbstractCartLoadRoute::class);
+        $cartLoadRoute
             ->expects($this->once())
             ->method('load')
-            ->with($cart->getToken(), $salesChannelContext)
-            ->willReturn($cart);
+            ->with(
+                static::callback(static function (Request $request) use ($cart): bool {
+                    static::assertSame($cart->getToken(), $request->query->get('token'));
+                    static::assertTrue($request->query->getBoolean('taxed'));
 
-        $calculator = $this->createMock(CartCalculator::class);
-        $calculator
-            ->expects($this->once())
-            ->method('calculate')
-            ->with($cart, $salesChannelContext)
-            ->willReturn($cart);
+                    return true;
+                }),
+                $salesChannelContext,
+            )
+            ->willReturn(new CartResponse($cart));
 
         return new CartService(
-            $persister,
+            $this->createMock(AbstractCartPersister::class),
             $this->createMock(EventDispatcherInterface::class),
-            $calculator,
-            new CartLoadRoute(
-                $persister,
-                $this->createMock(CartFactory::class),
-                $calculator,
-                $taxProviderProcessor,
-            ),
+            $this->createMock(CartCalculator::class),
+            $cartLoadRoute,
             $this->createMock(AbstractCartDeleteRoute::class),
             $this->createMock(AbstractCartItemAddRoute::class),
             $this->createMock(AbstractCartItemUpdateRoute::class),

--- a/tests/Checkout/SalesChannel/CreateOrderRouteTaxedCartTest.php
+++ b/tests/Checkout/SalesChannel/CreateOrderRouteTaxedCartTest.php
@@ -18,10 +18,10 @@ use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartLoadRoute;
 use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
-use Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartResponse;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
-use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\SalesChannel\AbstractSetPaymentOrderRoute;
 use Shopware\Core\Checkout\Payment\Cart\AbstractPaymentTransactionStructFactory;
@@ -61,12 +61,6 @@ class CreateOrderRouteTaxedCartTest extends TestCase
 
         $cart = new Cart('create-order-token');
 
-        $taxProviderProcessor = $this->createMock(TaxProviderProcessor::class);
-        $taxProviderProcessor
-            ->expects($this->once())
-            ->method('process')
-            ->with($cart, $salesChannelContext);
-
         $exception = new \RuntimeException('stop after taxed cart load');
 
         $payPalOrderBuilder = $this->createMock(PayPalOrderBuilder::class);
@@ -85,7 +79,7 @@ class CreateOrderRouteTaxedCartTest extends TestCase
             ->willThrowException($exception);
 
         $route = new CreateOrderRoute(
-            $this->createTaxedCartService($cart, $salesChannelContext, $taxProviderProcessor),
+            $this->createTaxedCartService($cart, $salesChannelContext),
             $this->createMock(EntityRepository::class),
             $payPalOrderBuilder,
             $this->createMock(ACDCOrderBuilder::class),
@@ -108,32 +102,27 @@ class CreateOrderRouteTaxedCartTest extends TestCase
     private function createTaxedCartService(
         Cart $cart,
         SalesChannelContext $salesChannelContext,
-        TaxProviderProcessor $taxProviderProcessor,
     ): CartService {
-        $persister = $this->createMock(AbstractCartPersister::class);
-        $persister
+        $cartLoadRoute = $this->createMock(AbstractCartLoadRoute::class);
+        $cartLoadRoute
             ->expects($this->once())
             ->method('load')
-            ->with($cart->getToken(), $salesChannelContext)
-            ->willReturn($cart);
+            ->with(
+                static::callback(static function (Request $request) use ($cart): bool {
+                    static::assertSame($cart->getToken(), $request->query->get('token'));
+                    static::assertTrue($request->query->getBoolean('taxed'));
 
-        $calculator = $this->createMock(CartCalculator::class);
-        $calculator
-            ->expects($this->once())
-            ->method('calculate')
-            ->with($cart, $salesChannelContext)
-            ->willReturn($cart);
+                    return true;
+                }),
+                $salesChannelContext,
+            )
+            ->willReturn(new CartResponse($cart));
 
         return new CartService(
-            $persister,
+            $this->createMock(AbstractCartPersister::class),
             $this->createMock(EventDispatcherInterface::class),
-            $calculator,
-            new CartLoadRoute(
-                $persister,
-                $this->createMock(CartFactory::class),
-                $calculator,
-                $taxProviderProcessor,
-            ),
+            $this->createMock(CartCalculator::class),
+            $cartLoadRoute,
             $this->createMock(AbstractCartDeleteRoute::class),
             $this->createMock(AbstractCartItemAddRoute::class),
             $this->createMock(AbstractCartItemUpdateRoute::class),


### PR DESCRIPTION
### 1. Why is this change necessary?

Every `trunk` job in CI is red, on `trunk` itself as well as on open pull requests, while all `v6.7.0.0` jobs pass. Core changed `CartLoadRoute` after 6.7.0.x: it no longer takes an `AbstractCartPersister` and a `CartFactory`, and it now asks the calculator for the cart by token instead of loading it from the persister and calculating it afterwards. The four taxed cart tests built the route the old way, which fails phpstan (12 errors) and phpunit (4 errors).

### 2. What does this change do, exactly?

These tests cover the PayPal routes, not `CartLoadRoute`. They only built a real route so that a cart came back out of `CartService`, and the mock expectations on its persister and calculator were plumbing — which is exactly what the core change breaks.

So they now mock `AbstractCartLoadRoute` and assert what the plugin is actually responsible for: that a taxed cart is requested, for the right token. Whether the route then runs the tax provider is core's behaviour, covered by core's own tests. `CartService::getCart` is identical on both versions — it builds a request carrying `token` and `taxed` and calls `load()` — so nothing in the tests is version dependent any more, and the assertions that matter (the PayPal order is built from that cart) are untouched.

### 3. Describe each step to reproduce the issue or behaviour.

`composer phpstan` and `composer phpunit -- tests/Checkout` against shopware trunk. Verified locally against trunk core: phpstan drops from 86 to 74 errors, exactly the 12 reported by CI, adding none; a deterministic (`--order-by=default`) run of `tests/Checkout` fixes precisely the four taxed cart tests and breaks nothing.

### 4. Please link to the relevant issues (if any).

<!-- none -->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

No changelog entry: this only touches tests, with no user-facing change — same as #790.

The trade-off worth a reviewer's eye: these tests no longer prove that `TaxProviderProcessor::process()` runs, only that a taxed cart is asked for. That felt like the right boundary for tests of the PayPal routes, but say the word if you would rather keep an integration-level test that exercises the real route.
