### PR TITLE
chore(phpstan): enable future compatibility rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,16 +52,16 @@ jobs:
           install-storefront: true
           shopware-version: ${{ matrix.PLATFORM_BRANCH }}
 
-      - name: Install PHPStan extensions
-        run: |
-          version="$(jq -r '."require-dev"["shopwarelabs/phpstan-shopware"]' custom/plugins/${{ github.event.repository.name }}/composer.json)"
-          # The future ruleset is included explicitly in the PHPStan config; do not auto-enable rules.neon.
-          symfony composer require --dev "shopwarelabs/phpstan-shopware:${version}" --no-interaction --no-plugins
-
       # @deprecated tag:v11.0.0 - step can be removed
       - name: Install dependencies
         if: matrix.PLATFORM_BRANCH == 'v6.7.0.0'
         run: composer require --dev phpstan/phpstan-strict-rules phpstan/phpstan:2.1.16
+
+      - name: Install PHPStan extensions
+        run: |
+          version="$(jq -r '."require-dev"["shopwarelabs/phpstan-shopware"]' custom/plugins/${{ github.event.repository.name }}/composer.json)"
+          # Keep this as the last Composer install: the future ruleset is included explicitly in the PHPStan config.
+          symfony composer require --dev "shopwarelabs/phpstan-shopware:${version}" --no-interaction --no-plugins
 
       - run: composer -d custom/plugins/${{ github.event.repository.name }} run phpstan
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,12 @@ jobs:
           install-storefront: true
           shopware-version: ${{ matrix.PLATFORM_BRANCH }}
 
+      - name: Install PHPStan extensions
+        run: |
+          version="$(jq -r '."require-dev"["shopwarelabs/phpstan-shopware"]' custom/plugins/${{ github.event.repository.name }}/composer.json)"
+          # The future ruleset is included explicitly in the PHPStan config; do not auto-enable rules.neon.
+          symfony composer require --dev "shopwarelabs/phpstan-shopware:${version}" --no-interaction --no-plugins
+
       # @deprecated tag:v11.0.0 - step can be removed
       - name: Install dependencies
         if: matrix.PLATFORM_BRANCH == 'v6.7.0.0'

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -34,7 +34,7 @@ $phpstanConfig = [
     ),
     'parameters' => [
         'symfony' => ['containerXmlPath' => \sprintf('%s/%s%sDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class), \ucfirst($kernel->getEnvironment()))],
-        'reportUnmatchedIgnoredErrors' => !((bool) $_SERVER['CI']),
+        'reportUnmatchedIgnoredErrors' => true,
     ],
 ];
 

--- a/bin/phpstan-config-generator.php
+++ b/bin/phpstan-config-generator.php
@@ -34,7 +34,7 @@ $phpstanConfig = [
     ),
     'parameters' => [
         'symfony' => ['containerXmlPath' => \sprintf('%s/%s%sDebugContainer.xml', $kernel->getCacheDir(), str_replace('\\', '_', $kernel::class), \ucfirst($kernel->getEnvironment()))],
-        'reportUnmatchedIgnoredErrors' => true,
+        'reportUnmatchedIgnoredErrors' => !((bool) $_SERVER['CI']),
     ],
 ];
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         "shopware/core": "~6.7.0@dev",
         "shopware/paypal-sdk": "^1.8.0"
     },
+    "require-dev": {
+        "shopwarelabs/phpstan-shopware": "0.2.4"
+    },
     "extra": {
         "shopware-plugin-class": "Swag\\PayPal\\SwagPayPal",
         "copyright": "(c) by shopware AG",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -89,53 +89,6 @@ parameters:
             identifier: method.deprecated
             message: '#__construct.*Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityDefinition.*#'
 
-        - # 6.8 deprecation
-            identifier: method.deprecated
-            message: '#arameter \$silent will be added in v6\.8\.0.*#'
-
-        - # 6.8 deprecation - only type change
-            identifier: method.deprecated
-            message: '#(setActiveBillingAddress|setActiveShippingAddress).*Shopware\\Core\\Checkout\\Customer\\CustomerEntity.*#'
-
-        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
-            identifier: method.deprecatedClass
-            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
-            path: '**/*.php'
-
-        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
-            identifier: return.deprecatedClass
-            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
-            path: '**/*.php'
-
-        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
-            identifier: new.deprecatedClass
-            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
-            path: '**/*.php'
-
-        - # 6.8 deprecation - EntitySearchResult is still the repository search result type on 6.7
-            identifier: classConstant.deprecatedClass
-            message: '#Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 reason:class-hierarchy-change - Will no longer extend EntityCollection, but will keep extending Struct\.#'
-            path: '**/*.php'
-
-        - # 6.8 deprecation - EntitySearchResult's collection shortcuts (first/get/getElements/reduce/...) move to
-          # getEntities()->...(); it is still the repository search result type on 6.7, so we keep using them.
-            identifier: method.deprecated
-            message: '#Call to deprecated method \w+\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:\s+tag:v6\.8\.0 - Will be removed\. Use getEntities\(\)->#'
-            path: '**/*.php'
-
-        - # 6.8 deprecation - EntitySearchResult constructor signature changes in v6.8; kept for 6.7 compatibility
-            identifier: method.deprecated
-            message: '#Call to deprecated method __construct\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult:#'
-            path: '**/*.php'
-
-        - # 6.8 deprecation - DAL field API will return static natively
-            identifier: method.deprecated
-            message: '#Call to deprecated method (addFlags|removeFlag)\(\) of class Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Field\:\s+tag\:v6\.8\.0 - reason\:return-type-change - Will return static natively#'
-            paths:
-                - src/DataAbstractionLayer
-                - src/Pos/DataAbstractionLayer
-                - src/Reporting/DataAbstractionLayer
-
         - # 6.8 deprecation - kept for 6.7.0.0 compatibility
             identifier: property.deprecatedInterface
             message: '#Property \$productStreamBuilder references deprecated interface Shopware\\Core\\Content\\ProductStream\\Service\\ProductStreamBuilderInterface in its type:#'
@@ -169,14 +122,6 @@ parameters:
             message: '#Parameter \#2 \$extension of method Shopware\\Core\\Framework\\Struct\\Struct::addExtension\(\) expects Shopware\\Core\\Framework\\Struct\\Struct, Shopware\\Core\\Framework\\Struct\\Struct\|null given#'
             paths:
                 - tests/Storefront/Data/FundingSubscriberTest.php
-
-        - # 6.8 deprecation - Parameter order still has to be changed
-            identifier: method.deprecated
-            message: '#Call to deprecated method __construct\(\) of class .*\\PaymentMethodBlockedError#'
-            paths:
-                - src/Checkout/Cart/Validation/CartValidator.php
-                - tests/Checkout/PUI/PUISubscriberTest.php
-                - tests/Storefront/Data/CheckoutSubscriberTest.php
 
         - # 6.8 deprecation - Will be removed
             message: '#Shopware\\Commercial\\Subscription\\Checkout\\Cart\\Recurring\\SubscriptionRecurringDataStruct#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 includes:
     - phpstan-baseline.neon
     - phpstan.dynamic.neon
+    - ../../../vendor/shopwarelabs/phpstan-shopware/future-compatibility.neon
 
 parameters:
     tmpDir: var/cache/phpstan

--- a/tests/Mock/Setting/Service/SystemConfigServiceMock.php
+++ b/tests/Mock/Setting/Service/SystemConfigServiceMock.php
@@ -93,7 +93,7 @@ class SystemConfigServiceMock extends SystemConfigService
     /**
      * @param int|float|string|bool|array|object|null $value
      */
-    public function set(string $key, $value, ?string $salesChannelId = null): void
+    public function set(string $key, $value, ?string $salesChannelId = null, bool $silent = true): void
     {
         $salesChannelId = (string) $salesChannelId;
         if (!isset($this->data[$salesChannelId])) {
@@ -102,7 +102,7 @@ class SystemConfigServiceMock extends SystemConfigService
         $this->data[$salesChannelId][$key] = $value;
     }
 
-    public function delete(string $key, ?string $salesChannel = null): void
+    public function delete(string $key, ?string $salesChannel = null, bool $silent = true): void
     {
         $this->set($key, null, $salesChannel);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

PayPal should run Shopware's dedicated future-compatibility PHPStan rules so upcoming Shopware API changes are detected during plugin development and CI.

### 2. What does this change do, exactly?

- Adds `shopwarelabs/phpstan-shopware` 0.2.4 as a development dependency.
- Includes only `future-compatibility.neon` in the plugin PHPStan configuration.
- Installs the PHPStan extension with `--no-plugins` in CI so the package's default ruleset is not enabled.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the plugin PHPStan command in CI or a Shopware development environment.
2. PHPStan loads the explicitly included future-compatibility rules.
3. The package's default `rules.neon` is not auto-enabled.

### 4. Please link to the relevant issues (if any).

Related implementation: [SwagCommercial#3133](https://github.com/shopware/SwagCommercial/pull/3133)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created an entry in the CHANGELOG.md files with all necessary user information about my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
